### PR TITLE
Downcast ByteBuffer to Buffer

### DIFF
--- a/mojo/public/java/bindings/src/org/chromium/mojo/bindings/Decoder.java
+++ b/mojo/public/java/bindings/src/org/chromium/mojo/bindings/Decoder.java
@@ -12,6 +12,7 @@ import org.chromium.mojo.system.MessagePipeHandle;
 import org.chromium.mojo.system.SharedBufferHandle;
 import org.chromium.mojo.system.UntypedHandle;
 
+import java.nio.Buffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 
@@ -332,7 +333,7 @@ public class Decoder {
         }
         DataHeader si = d.readDataHeaderForBooleanArray(expectedLength);
         byte[] bytes = new byte[(si.elementsOrVersion + 7) / BindingsHelper.ALIGNMENT];
-        d.mMessage.getData().position(d.mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) d.mMessage.getData()).position(d.mBaseOffset + DataHeader.HEADER_SIZE);
         d.mMessage.getData().get(bytes);
         boolean[] result = new boolean[si.elementsOrVersion];
         for (int i = 0; i < bytes.length; ++i) {
@@ -356,7 +357,7 @@ public class Decoder {
         }
         DataHeader si = d.readDataHeaderForArray(1, expectedLength);
         byte[] result = new byte[si.elementsOrVersion];
-        d.mMessage.getData().position(d.mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) d.mMessage.getData()).position(d.mBaseOffset + DataHeader.HEADER_SIZE);
         d.mMessage.getData().get(result);
         return result;
     }
@@ -371,7 +372,7 @@ public class Decoder {
         }
         DataHeader si = d.readDataHeaderForArray(2, expectedLength);
         short[] result = new short[si.elementsOrVersion];
-        d.mMessage.getData().position(d.mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) d.mMessage.getData()).position(d.mBaseOffset + DataHeader.HEADER_SIZE);
         d.mMessage.getData().asShortBuffer().get(result);
         return result;
     }
@@ -386,7 +387,7 @@ public class Decoder {
         }
         DataHeader si = d.readDataHeaderForArray(4, expectedLength);
         int[] result = new int[si.elementsOrVersion];
-        d.mMessage.getData().position(d.mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) d.mMessage.getData()).position(d.mBaseOffset + DataHeader.HEADER_SIZE);
         d.mMessage.getData().asIntBuffer().get(result);
         return result;
     }
@@ -401,7 +402,7 @@ public class Decoder {
         }
         DataHeader si = d.readDataHeaderForArray(4, expectedLength);
         float[] result = new float[si.elementsOrVersion];
-        d.mMessage.getData().position(d.mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) d.mMessage.getData()).position(d.mBaseOffset + DataHeader.HEADER_SIZE);
         d.mMessage.getData().asFloatBuffer().get(result);
         return result;
     }
@@ -416,7 +417,7 @@ public class Decoder {
         }
         DataHeader si = d.readDataHeaderForArray(8, expectedLength);
         long[] result = new long[si.elementsOrVersion];
-        d.mMessage.getData().position(d.mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) d.mMessage.getData()).position(d.mBaseOffset + DataHeader.HEADER_SIZE);
         d.mMessage.getData().asLongBuffer().get(result);
         return result;
     }
@@ -431,7 +432,7 @@ public class Decoder {
         }
         DataHeader si = d.readDataHeaderForArray(8, expectedLength);
         double[] result = new double[si.elementsOrVersion];
-        d.mMessage.getData().position(d.mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) d.mMessage.getData()).position(d.mBaseOffset + DataHeader.HEADER_SIZE);
         d.mMessage.getData().asDoubleBuffer().get(result);
         return result;
     }

--- a/mojo/public/java/bindings/src/org/chromium/mojo/bindings/Encoder.java
+++ b/mojo/public/java/bindings/src/org/chromium/mojo/bindings/Encoder.java
@@ -10,6 +10,7 @@ import org.chromium.mojo.system.Handle;
 import org.chromium.mojo.system.MessagePipeHandle;
 import org.chromium.mojo.system.Pair;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
@@ -84,8 +85,8 @@ public class Encoder {
             }
             ByteBuffer newBuffer = ByteBuffer.allocateDirect(targetSize);
             newBuffer.order(ByteOrder.nativeOrder());
-            byteBuffer.position(0);
-            byteBuffer.limit(byteBuffer.capacity());
+            ((Buffer) byteBuffer).position(0);
+            ((Buffer) byteBuffer).limit(byteBuffer.capacity());
             newBuffer.put(byteBuffer);
             byteBuffer = newBuffer;
         }
@@ -110,8 +111,8 @@ public class Encoder {
      * Returns the result message.
      */
     public Message getMessage() {
-        mEncoderState.byteBuffer.position(0);
-        mEncoderState.byteBuffer.limit(mEncoderState.dataEnd);
+        ((Buffer) mEncoderState.byteBuffer).position(0);
+        ((Buffer) mEncoderState.byteBuffer).limit(mEncoderState.dataEnd);
         return new Message(mEncoderState.byteBuffer, mEncoderState.handles);
     }
 
@@ -555,32 +556,32 @@ public class Encoder {
     }
 
     private void append(byte[] v) {
-        mEncoderState.byteBuffer.position(mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) mEncoderState.byteBuffer).position(mBaseOffset + DataHeader.HEADER_SIZE);
         mEncoderState.byteBuffer.put(v);
     }
 
     private void append(short[] v) {
-        mEncoderState.byteBuffer.position(mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) mEncoderState.byteBuffer).position(mBaseOffset + DataHeader.HEADER_SIZE);
         mEncoderState.byteBuffer.asShortBuffer().put(v);
     }
 
     private void append(int[] v) {
-        mEncoderState.byteBuffer.position(mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) mEncoderState.byteBuffer).position(mBaseOffset + DataHeader.HEADER_SIZE);
         mEncoderState.byteBuffer.asIntBuffer().put(v);
     }
 
     private void append(float[] v) {
-        mEncoderState.byteBuffer.position(mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) mEncoderState.byteBuffer).position(mBaseOffset + DataHeader.HEADER_SIZE);
         mEncoderState.byteBuffer.asFloatBuffer().put(v);
     }
 
     private void append(double[] v) {
-        mEncoderState.byteBuffer.position(mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) mEncoderState.byteBuffer).position(mBaseOffset + DataHeader.HEADER_SIZE);
         mEncoderState.byteBuffer.asDoubleBuffer().put(v);
     }
 
     private void append(long[] v) {
-        mEncoderState.byteBuffer.position(mBaseOffset + DataHeader.HEADER_SIZE);
+        ((Buffer) mEncoderState.byteBuffer).position(mBaseOffset + DataHeader.HEADER_SIZE);
         mEncoderState.byteBuffer.asLongBuffer().put(v);
     }
 

--- a/mojo/public/java/bindings/src/org/chromium/mojo/bindings/ServiceMessage.java
+++ b/mojo/public/java/bindings/src/org/chromium/mojo/bindings/ServiceMessage.java
@@ -4,6 +4,7 @@
 
 package org.chromium.mojo.bindings;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -56,7 +57,7 @@ public class ServiceMessage extends Message {
     public Message getPayload() {
         if (mPayload == null) {
             ByteBuffer truncatedBuffer =
-                    ((ByteBuffer) getData().position(getHeader().getSize())).slice();
+                    ((ByteBuffer) ((Buffer) getData()).position(getHeader().getSize())).slice();
             truncatedBuffer.order(ByteOrder.LITTLE_ENDIAN);
             mPayload = new Message(truncatedBuffer, getHandles());
         }

--- a/mojo/public/java/system/src/org/chromium/mojo/system/impl/CoreImpl.java
+++ b/mojo/public/java/system/src/org/chromium/mojo/system/impl/CoreImpl.java
@@ -27,6 +27,7 @@ import org.chromium.mojo.system.SharedBufferHandle.MapFlags;
 import org.chromium.mojo.system.UntypedHandle;
 import org.chromium.mojo.system.Watcher;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -243,7 +244,7 @@ public class CoreImpl implements Core {
                 // succeeds below, so we unconditionally release them here.
                 handlesBuffer.putLong(handle.releaseNativeHandle());
             }
-            handlesBuffer.position(0);
+            ((Buffer) handlesBuffer).position(0);
         }
         int mojoResult = CoreImplJni.get().writeMessage(CoreImpl.this, pipeHandle.getMojoHandle(),
                 bytes, bytes == null ? 0 : bytes.limit(), handlesBuffer, flags.getFlags());


### PR DESCRIPTION
This CL solves the java error message, 'java.lang.NoSuchMethodError: No virtual method position(I)Ljava/nio/ByteBuffer; in class Ljava/nio/ByteBuffer;'.

In Java 8 used by Wolvic, the class ByteBuffer inherits the position method from the class Buffer and has a return type of java.nio.Buffer. On Java 11 and lather used by chromium, the method is overridden with an implementation that returns java.nio.ByteBuffer.

So, this changes to do explicitly the downcast from the class ByteBuffer to the class Buffer for the backward compatibility according to the Java version.