### PR TITLE
Add jni codes to create WebContents for wolvic

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -18,6 +18,7 @@ shared_library("libcontent_native") {
   testonly = true
   sources = [
     "../content/shell/browser/shell_paths.cc",
+    "browser/tab_jni.cc",
     "wolvic_browser_context.cc",
     "wolvic_browser_context.h",
     "wolvic_content_browser_client.cc",
@@ -32,6 +33,7 @@ shared_library("libcontent_native") {
   ]
   deps = [
     ":content_native_lib",
+    ":jni_headers",
     "//components/crash/content/browser",
     "//media",
     "//skia",
@@ -157,10 +159,25 @@ jinja_template("content_manifest") {
   output = "$root_gen_dir/wolvic/AndroidManifest.xml"
 }
 
+generate_jni("jni_headers") {
+  sources = [ "java/org/chromium/wolvic/Tab.java" ]
+}
+
+android_library("jni_java") {
+  sources = [ "java/org/chromium/wolvic/Tab.java" ]
+  annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+  deps = [
+    "//base:jni_java",
+    "//build/android:build_java",
+    "//content/public/android:content_full_java",
+  ]
+}
+
 dist_aar("content_aar") {
   testonly = true
   deps = [
     ":content_manifest",
+    ":jni_java",
     ":libcontent_native",
     "//base",
     "//base:base_java",
@@ -204,6 +221,7 @@ dist_aar("content_aar") {
     "org/chromium/service_manager/mojom/*.class",
     "org/chromium/services/*.class",
     "org/chromium/url/*.class",
+    "org/chromium/wolvic/*.class",
   ]
   resource_included_patterns = [ "*/content/public/*" ]
   jar_excluded_patterns = [

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -19,10 +19,9 @@ base::android::ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
   auto* delegate = content::WolvicContentMainDelegate::Get();
   CHECK(delegate->browser_context() != nullptr);
 
-  WebContents::CreateParams create_params(
-      static_cast<BrowserContext*>(delegate->browser_context()), nullptr);
   std::unique_ptr<WebContents> web_contents =
-      WebContents::Create(create_params);
+      WebContents::Create(content::WebContents::CreateParams(
+          static_cast<BrowserContext*>(delegate->browser_context())));
 
   // TODO: This is just for the proof-of-concept and URL should be loaded
   // explicitly by `NavigationController.loadUrl` after creating WebContents.

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -1,0 +1,37 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/jni_headers/Tab_jni.h"
+
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/web_contents.h"
+#include "url/gurl.h"
+#include "wolvic/wolvic_browser_context.h"
+#include "wolvic/wolvic_content_main_delegate.h"
+
+namespace content {
+
+base::android::ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
+    JNIEnv* env) {
+  // TODO(wolvic-chromium#6): Consider handling browser profiles.
+  auto* delegate = content::WolvicContentMainDelegate::Get();
+  CHECK(delegate->browser_context() != nullptr);
+
+  WebContents::CreateParams create_params(
+      static_cast<BrowserContext*>(delegate->browser_context()), nullptr);
+  std::unique_ptr<WebContents> web_contents =
+      WebContents::Create(create_params);
+
+  // TODO: This is just for the proof-of-concept and URL should be loaded
+  // explicitly by `NavigationController.loadUrl` after creating WebContents.
+  NavigationController::LoadURLParams params(GURL("https://google.com"));
+  params.transition_type = static_cast<ui::PageTransition>(
+      ui::PAGE_TRANSITION_TYPED | ui::PAGE_TRANSITION_FROM_ADDRESS_BAR);
+  web_contents->GetController().LoadURLWithParams(params);
+
+  return web_contents.release()->GetJavaWebContents();
+}
+
+}  // namespace content

--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -1,0 +1,17 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.content_public.browser.WebContents;
+
+@JNINamespace("content")
+public class Tab {
+    @NativeMethods
+    public interface Natives {
+        WebContents createWebContents();
+    }
+}

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -34,7 +34,7 @@ std::string WolvicContentBrowserClient::GetUserAgent() {
 
 std::string WolvicContentBrowserClient::GetUserAgentBasedOnPolicy(
     content::BrowserContext* context) {
-  auto* delegate = GetWolvicContentMainDelegate();
+  auto* delegate = WolvicContentMainDelegate::Get();
 
   const PrefService* prefs = delegate->GetPrefs();
   embedder_support::ForceMajorVersionToMinorPosition

--- a/wolvic/wolvic_content_main_delegate.cc
+++ b/wolvic/wolvic_content_main_delegate.cc
@@ -98,30 +98,6 @@ void InitLogging(const base::CommandLine& command_line) {
 
 namespace content {
 
-WolvicContentMainDelegate* GetWolvicContentMainDelegate() {
-  LOG(ERROR) << "WolvicLifecycle GetWolvicContentMainDelegate()";
-  return static_cast<WolvicContentMainDelegate*>(
-      GetContentMainDelegateForTesting());
-}
-
-jobject CreateWebContents(JNIEnv* env, WolvicContentMainDelegate* delegate) {
-  LOG(ERROR) << "WolvicLifecycle CreateWebContents()";
-  CHECK(delegate->browser_context() != nullptr);
-
-  WebContents::CreateParams create_params(
-      static_cast<BrowserContext*>(delegate->browser_context()), nullptr);
-  delegate->web_contents_list_.push_back(WebContents::Create(create_params));
-  WebContents* web_contents = delegate->web_contents_list_.back().get();
-
-  NavigationController::LoadURLParams params(GURL("https://google.com"));
-  params.frame_name = "";
-  params.transition_type = static_cast<ui::PageTransition>(
-      ui::PAGE_TRANSITION_TYPED | ui::PAGE_TRANSITION_FROM_ADDRESS_BAR);
-  web_contents->GetController().LoadURLWithParams(params);
-
-  return env->NewGlobalRef(web_contents->GetJavaWebContents().obj());
-}
-
 // TODO(crbug/1219642): Consider not needing VariationsServiceClient just to use
 // VariationsFieldTrialCreator.
 class ShellVariationsServiceClient
@@ -180,6 +156,12 @@ base::flat_set<url::Origin> GetIsolatedContextOriginSetFromFlag() {
 WolvicContentMainDelegate::WolvicContentMainDelegate() {}
 
 WolvicContentMainDelegate::~WolvicContentMainDelegate() {}
+
+// static
+WolvicContentMainDelegate* WolvicContentMainDelegate::Get() {
+  return static_cast<WolvicContentMainDelegate*>(
+      GetContentMainDelegateForTesting());
+}
 
 absl::optional<int> WolvicContentMainDelegate::BasicStartupComplete() {
   LOG(ERROR) << "WolvicLifecycle BasicStartupComplete()";

--- a/wolvic/wolvic_content_main_delegate.h
+++ b/wolvic/wolvic_content_main_delegate.h
@@ -24,12 +24,6 @@ class WolvicContentBrowserClient;
 class WolvicContentClient;
 class WolvicContentMainDelegate;
 
-__attribute__((visibility("default"))) WolvicContentMainDelegate*
-GetWolvicContentMainDelegate();
-__attribute__((visibility("default"))) jobject CreateWebContents(
-    JNIEnv* env,
-    WolvicContentMainDelegate* delegate);
-
 class WolvicContentMainDelegate : public ContentMainDelegate {
  public:
   explicit WolvicContentMainDelegate();
@@ -39,6 +33,8 @@ class WolvicContentMainDelegate : public ContentMainDelegate {
       delete;
 
   ~WolvicContentMainDelegate() override;
+
+  static WolvicContentMainDelegate* Get();
 
   // ContentMainDelegate implementation:
   absl::optional<int> BasicStartupComplete() override;
@@ -58,15 +54,14 @@ class WolvicContentMainDelegate : public ContentMainDelegate {
 
   static void InitializeResourceBundle();
 
-  friend WolvicContentMainDelegate* GetWolvicContentMainDelegate();
-  friend jobject CreateWebContents(JNIEnv* env,
-                                   WolvicContentMainDelegate* delegate);
-
   WolvicBrowserContext* browser_context();
 
   PrefService* GetPrefs() { return local_state_.get(); }
 
  protected:
+  friend base::android::ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
+      JNIEnv* env);
+
   void CreateFeatureListAndFieldTrials();
   std::unique_ptr<PrefService> CreateLocalState();
   void SetUpFieldTrials();
@@ -77,8 +72,6 @@ class WolvicContentMainDelegate : public ContentMainDelegate {
   std::unique_ptr<ContentRendererClient> renderer_client_;
   std::unique_ptr<ContentUtilityClient> utility_client_;
   std::unique_ptr<WolvicContentClient> content_client_;
-
-  std::vector<std::unique_ptr<WebContents>> web_contents_list_;
 };
 
 }  // namespace content


### PR DESCRIPTION
This CL add jni codes to create WebContents for wolvic with the newly created java class `Tab`.