### PR TITLE
Wolvic expose media apis

### DIFF
--- a/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java
+++ b/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java
@@ -197,7 +197,8 @@ public class MediaSessionHelper implements MediaImageCallback {
             }
 
             @Override
-            public void mediaSessionStateChanged(boolean isControllable, boolean isPaused) {
+            public void mediaSessionStateChanged(
+                    boolean isControllable, boolean isPaused, boolean isActive) {
                 if (!isControllable) {
                     hideNotificationDelayed();
                     return;

--- a/content/browser/media/session/media_session_android.cc
+++ b/content/browser/media/session/media_session_android.cc
@@ -83,20 +83,26 @@ void MediaSessionAndroid::MediaSessionInfoChanged(
   bool is_paused = session_info->playback_state ==
                    media_session::mojom::MediaPlaybackState::kPaused;
 
+  bool is_active =
+      session_info->state !=
+      media_session::mojom::MediaSessionInfo::SessionState::kInactive;
+
   // The media session info changed event might be called more often than we
   // need to notify Android since we only need a couple of bits of data.
   // Therefore, we only notify Android if the bits have changed.
-  if (is_paused == is_paused_ &&
+  if (is_active == is_active_ && is_paused == is_paused_ &&
       is_controllable_ == session_info->is_controllable) {
     return;
   }
 
+  is_active_ = is_active;
   is_paused_ = is_paused;
   is_controllable_ = session_info->is_controllable;
 
   JNIEnv* env = base::android::AttachCurrentThread();
-  Java_MediaSessionImpl_mediaSessionStateChanged(
-      env, j_local_session, session_info->is_controllable, is_paused);
+  Java_MediaSessionImpl_mediaSessionStateChanged(env, j_local_session,
+                                                 session_info->is_controllable,
+                                                 is_paused, is_active_);
 }
 
 void MediaSessionAndroid::MediaSessionMetadataChanged(
@@ -211,6 +217,23 @@ void MediaSessionAndroid::SeekTo(
   DCHECK(media_session_);
   DCHECK_GE(millis, 0) << "Attempted to seek to a negative position";
   media_session_->SeekTo(base::Milliseconds(millis));
+}
+
+void MediaSessionAndroid::ScrubTo(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jobject>& j_obj,
+    const jlong millis) {
+  DCHECK(media_session_);
+  DCHECK_GE(millis, 0) << "Attempted to seek to a negative position";
+  media_session_->ScrubTo(base::Milliseconds(millis));
+}
+
+void MediaSessionAndroid::SetMute(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jobject>& j_obj,
+    const jboolean mute) {
+  DCHECK(media_session_);
+  media_session_->SetMute(mute);
 }
 
 void MediaSessionAndroid::DidReceiveAction(JNIEnv* env,

--- a/content/browser/media/session/media_session_android.h
+++ b/content/browser/media/session/media_session_android.h
@@ -63,6 +63,12 @@ class MediaSessionAndroid final
   void SeekTo(JNIEnv* env,
               const base::android::JavaParamRef<jobject>& j_obj,
               const jlong millis);
+  void ScrubTo(JNIEnv* env,
+               const base::android::JavaParamRef<jobject>& j_obj,
+               const jlong millis);
+  void SetMute(JNIEnv* env,
+               const base::android::JavaParamRef<jobject>& j_obj,
+               const jboolean mute);
   void DidReceiveAction(JNIEnv* env,
                         const base::android::JavaParamRef<jobject>& j_obj,
                         jint action);
@@ -84,6 +90,7 @@ class MediaSessionAndroid final
 
   bool is_paused_ = false;
   bool is_controllable_ = false;
+  bool is_active_ = false;
 
   mojo::Receiver<media_session::mojom::MediaSessionObserver> observer_receiver_{
       this};

--- a/content/public/android/java/src/org/chromium/content/browser/MediaSessionImpl.java
+++ b/content/public/android/java/src/org/chromium/content/browser/MediaSessionImpl.java
@@ -35,6 +35,7 @@ public class MediaSessionImpl extends MediaSession {
 
     private boolean mIsControllable;
     private Boolean mIsSuspended;
+    private boolean mIsActive;
     private MediaMetadata mMetadata;
     private List<MediaImage> mImagesList;
     private HashSet<Integer> mActionSet;
@@ -47,7 +48,7 @@ public class MediaSessionImpl extends MediaSession {
     public void addObserver(MediaSessionObserver observer) {
         mObservers.addObserver(observer);
         if (mIsSuspended != null) {
-            observer.mediaSessionStateChanged(mIsControllable, mIsSuspended);
+            observer.mediaSessionStateChanged(mIsControllable, mIsSuspended, mIsActive);
         }
         if (mMetadata != null) {
             observer.mediaSessionMetadataChanged(mMetadata);
@@ -100,6 +101,17 @@ public class MediaSessionImpl extends MediaSession {
     }
 
     @Override
+    public void scrubTo(long millis) {
+        assert millis >= 0 : "Attempted to scrub to a negative posision";
+        MediaSessionImplJni.get().seekTo(mNativeMediaSessionAndroid, MediaSessionImpl.this, millis);
+    }
+
+    @Override
+    public void setMute(boolean mute) {
+        MediaSessionImplJni.get().setMute(mNativeMediaSessionAndroid, MediaSessionImpl.this, mute);
+    }
+
+    @Override
     public void didReceiveAction(int action) {
         MediaSessionImplJni.get().didReceiveAction(
                 mNativeMediaSessionAndroid, MediaSessionImpl.this, action);
@@ -134,12 +146,15 @@ public class MediaSessionImpl extends MediaSession {
     }
 
     @CalledByNative
-    private void mediaSessionStateChanged(boolean isControllable, boolean isSuspended) {
+    private void mediaSessionStateChanged(
+            boolean isControllable, boolean isSuspended, boolean isActive) {
         mIsControllable = isControllable;
         mIsSuspended = isSuspended;
+        mIsActive = isActive;
 
         for (mObserversIterator.rewind(); mObserversIterator.hasNext();) {
-            mObserversIterator.next().mediaSessionStateChanged(isControllable, isSuspended);
+            mObserversIterator.next().mediaSessionStateChanged(
+                    isControllable, isSuspended, isActive);
         }
     }
 
@@ -197,6 +212,8 @@ public class MediaSessionImpl extends MediaSession {
         void stop(long nativeMediaSessionAndroid, MediaSessionImpl caller);
         void seek(long nativeMediaSessionAndroid, MediaSessionImpl caller, long millis);
         void seekTo(long nativeMediaSessionAndroid, MediaSessionImpl caller, long millis);
+        void scrubTo(long nativeMediaSessionAndroid, MediaSessionImpl caller, long millis);
+        void setMute(long nativeMediaSessionAndroid, MediaSessionImpl caller, boolean mute);
         void didReceiveAction(long nativeMediaSessionAndroid, MediaSessionImpl caller, int action);
         void requestSystemAudioFocus(long nativeMediaSessionAndroid, MediaSessionImpl caller);
         MediaSessionImpl getMediaSessionFromWebContents(WebContents contents);

--- a/content/public/android/java/src/org/chromium/content_public/browser/MediaSession.java
+++ b/content/public/android/java/src/org/chromium/content_public/browser/MediaSession.java
@@ -59,6 +59,17 @@ public abstract class MediaSession {
     public abstract void seekTo(long millis);
 
     /**
+     * Scrubs ("fast seek") the media session to a specific point relative from the beginning
+     * of the media. The number of milliseconds should not be negative.
+     */
+    public abstract void scrubTo(long millis);
+
+    /**
+     * Mutes the media session.
+     */
+    public abstract void setMute(boolean mute);
+
+    /**
      * Notify the media session that an action has been performed.
      */
     public abstract void didReceiveAction(int action);

--- a/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java
+++ b/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java
@@ -58,8 +58,10 @@ public abstract class MediaSessionObserver {
      * Called when the observed {@link MediaSession} state has changed.
      * @param isControllable If the session can be resumed or suspended.
      * @param isSuspended if the session currently suspended or not.
+     * @param isActive if the session is active.
      */
-    public void mediaSessionStateChanged(boolean isControllable, boolean isSuspended) {}
+    public void mediaSessionStateChanged(
+            boolean isControllable, boolean isSuspended, boolean isActive) {}
 
     /**
      * Called when the {@link MediaSession} metadata has changed.

--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -82,6 +82,7 @@ static_library("content_native_lib") {
     "//components/custom_handlers",
     "//components/custom_handlers:test_support",
     "//components/embedder_support:browser_util",
+    "//components/embedder_support/android:web_contents_delegate",
     "//components/keyed_service/content",
     "//components/metrics",
     "//components/metrics:net",
@@ -169,6 +170,7 @@ android_library("jni_java") {
   deps = [
     "//base:jni_java",
     "//build/android:build_java",
+    "//components/embedder_support/android:web_contents_delegate_java",
     "//content/public/android:content_full_java",
   ]
 }
@@ -182,6 +184,7 @@ dist_aar("content_aar") {
     "//base",
     "//base:base_java",
     "//base:jni_java",
+    "//components/browser_ui/media/android:java",
     "//components/embedder_support/android:view_java",
     "//components/metrics:metrics_java",
     "//components/viz/service:service_java",
@@ -206,6 +209,8 @@ dist_aar("content_aar") {
     "org/chromium/base/*.class",
     "org/chromium/blink/mojom/*.class",
     "org/chromium/build/*.class",
+    "org/chromium/components/browser_ui/media/*.class",
+    "org/chromium/components/embedder_support/delegate/*.class",
     "org/chromium/components/embedder_support/view/*.class",
     "org/chromium/components/metrics/*.class",
     "org/chromium/components/variations/*.class",
@@ -214,6 +219,7 @@ dist_aar("content_aar") {
     "org/chromium/content/*.class",
     "org/chromium/device/*",
     "org/chromium/media/*.class",
+    "org/chromium/media_session/mojom/*.class",
     "org/chromium/mojo_base/mojom/*.class",
     "org/chromium/mojo/bindings/*.class",
     "org/chromium/mojo/system/*.class",

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -4,6 +4,7 @@
 
 #include "wolvic/jni_headers/Tab_jni.h"
 
+#include "components/embedder_support/android/delegate/web_contents_delegate_android.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/web_contents.h"
@@ -11,10 +12,13 @@
 #include "wolvic/wolvic_browser_context.h"
 #include "wolvic/wolvic_content_main_delegate.h"
 
+using base::android::JavaParamRef;
+using base::android::ScopedJavaLocalRef;
+using web_contents_delegate_android::WebContentsDelegateAndroid;
+
 namespace content {
 
-base::android::ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
-    JNIEnv* env) {
+ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(JNIEnv* env) {
   // TODO(wolvic-chromium#6): Consider handling browser profiles.
   auto* delegate = content::WolvicContentMainDelegate::Get();
   CHECK(delegate->browser_context() != nullptr);
@@ -31,6 +35,20 @@ base::android::ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
   web_contents->GetController().LoadURLWithParams(params);
 
   return web_contents.release()->GetJavaWebContents();
+}
+
+void JNI_Tab_SetWebContentsDelegate(
+    JNIEnv* env,
+    const JavaParamRef<jobject>& jweb_contents,
+    const JavaParamRef<jobject>& jweb_contents_delegate) {
+  WebContents* web_contents = WebContents::FromJavaWebContents(jweb_contents);
+  static std::unique_ptr<WebContentsDelegateAndroid> web_contents_delegate;
+
+  DCHECK(web_contents);
+
+  web_contents_delegate =
+      std::make_unique<WebContentsDelegateAndroid>(env, jweb_contents_delegate);
+  web_contents->SetDelegate(web_contents_delegate.get());
 }
 
 }  // namespace content

--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -6,12 +6,23 @@ package org.chromium.wolvic;
 
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
+import org.chromium.components.embedder_support.delegate.WebContentsDelegateAndroid;
 import org.chromium.content_public.browser.WebContents;
 
 @JNINamespace("content")
 public class Tab {
+    public WebContents createWebContents() {
+        return TabJni.get().createWebContents();
+    }
+
+    public void setWebContentsDelegate(
+            WebContents webContents, WebContentsDelegateAndroid delegate) {
+        TabJni.get().setWebContentsDelegate(webContents, delegate);
+    }
+
     @NativeMethods
     public interface Natives {
         WebContents createWebContents();
+        void setWebContentsDelegate(WebContents webContents, WebContentsDelegateAndroid delegate);
     }
 }


### PR DESCRIPTION
Support fullscreen & media control
    
This CL exposes fullscreen and media APIs to Java layer to support fullcreen and media control.
- Add setWebContentsDelegate in tab jni to enter/exit fullcreen
- Expose scrubTo(=fast seek)/setMute to Java layer
- Add a |isActive| parameter to determind the media start/stop status
- Add //components/browser_ui/media/* in gn to handle the artwork's images
