### PR TITLE
Remove default page loading & add UrlFormatter

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -213,6 +213,7 @@ dist_aar("content_aar") {
     "org/chromium/components/embedder_support/delegate/*.class",
     "org/chromium/components/embedder_support/view/*.class",
     "org/chromium/components/metrics/*.class",
+    "org/chromium/components/url_formatter/*.class",
     "org/chromium/components/variations/*.class",
     "org/chromium/components/viz/service/frame_sinks/*.class",
     "org/chromium/content_public/*.class",

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -27,13 +27,6 @@ ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(JNIEnv* env) {
       WebContents::Create(content::WebContents::CreateParams(
           static_cast<BrowserContext*>(delegate->browser_context())));
 
-  // TODO: This is just for the proof-of-concept and URL should be loaded
-  // explicitly by `NavigationController.loadUrl` after creating WebContents.
-  NavigationController::LoadURLParams params(GURL("https://google.com"));
-  params.transition_type = static_cast<ui::PageTransition>(
-      ui::PAGE_TRANSITION_TYPED | ui::PAGE_TRANSITION_FROM_ADDRESS_BAR);
-  web_contents->GetController().LoadURLWithParams(params);
-
   return web_contents.release()->GetJavaWebContents();
 }
 


### PR DESCRIPTION
This is a support change for the basic navigation implementation on the wolvic side. Get rid of the default page loading since it'll be handled by the wolvic browser. Also add UrlFormatter dependency to support url fomatting consistent with chromium.