### PR TITLE
Fix the build error after PR 10

### DIFF
--- a/content/browser/xr/service/vr_service_impl.cc
+++ b/content/browser/xr/service/vr_service_impl.cc
@@ -704,7 +704,7 @@ void VRServiceImpl::DoRequestSession(SessionRequestData request) {
   runtime_options->optional_features.assign(request.optional_features.begin(),
                                             request.optional_features.end());
 
-#if BUILDFLAG(IS_ANDROID)  // && BUILDFLAG(ENABLE_ARCORE)
+#if BUILDFLAG(IS_ANDROID) && BUILDFLAG(ENABLE_ARCORE)
   if (request.runtime_id == device::mojom::XRDeviceId::ARCORE_DEVICE_ID ||
       request.runtime_id == device::mojom::XRDeviceId::WVR_DEVICE_ID) {
     runtime_options->render_process_id =

--- a/wolvic/browser/vr/wvr_device.cc
+++ b/wolvic/browser/vr/wvr_device.cc
@@ -11,6 +11,7 @@
 #include "content/public/browser/web_contents.h"
 #include "device/vr/public/mojom/isolated_xr_service.mojom.h"
 #include "device/vr/public/mojom/vr_service.mojom.h"
+#include "ui/android/view_android.h"
 #include "ui/display/display.h"
 #include "ui/display/screen.h"
 
@@ -29,19 +30,6 @@ const std::vector<device::mojom::XRSessionFeature>& GetSupportedFeatures() {
            device::mojom::XRSessionFeature::ANCHORS}};
 
   return *kSupportedFeatures;
-}
-
-content::WebContents* GetWebContents(int render_process_id,
-                                     int render_frame_id) {
-  content::RenderFrameHost* render_frame_host =
-      content::RenderFrameHost::FromID(render_process_id, render_frame_id);
-  DCHECK(render_frame_host);
-
-  content::WebContents* web_contents =
-      content::WebContents::FromRenderFrameHost(render_frame_host);
-  DCHECK(web_contents);
-
-  return web_contents;
 }
 
 }  // namespace
@@ -115,13 +103,10 @@ bool WvrDevice::IsOnMainThread() {
 
 void WvrDevice::OnWvrThreadReady(
     device::mojom::XRRuntimeSessionOptionsPtr options) {
-  content::WebContents* web_contents =
-      GetWebContents(options->render_process_id, options->render_frame_id);
   display::Display display = display::Screen::GetScreen()->GetPrimaryDisplay();
-
   PostTaskToWvrThread(base::BindOnce(
       &WvrManager::InitializeGl, wvr_thread_->GetWvrManager()->GetWeakPtr(),
-      web_contents->GetTopLevelNativeWindow(), display.GetSizeInPixel(),
+      display.GetSizeInPixel(),
       CreateMainThreadCallback(
           base::BindOnce(&WvrDevice::OnWvrGlInitializationComplete,
                          GetWeakPtr(), std::move(options)))));

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -123,8 +123,7 @@ WvrManager::~WvrManager() {
   webxr_->EndPresentation();
 }
 
-void WvrManager::InitializeGl(ui::WindowAndroid* root_window,
-                              const gfx::Size& frame_size,
+void WvrManager::InitializeGl(const gfx::Size& frame_size,
                               base::OnceClosure callback) {
   screen_size_ = frame_size;
 

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -23,7 +23,6 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "ui/gfx/geometry/rect_f.h"
 #include "ui/gfx/geometry/size.h"
-#include "ui/gfx/native_widget_types.h"
 #include "ui/gl/gl_helper.h"
 #include "wolvic/browser/vr/moz_external_vr.h"
 
@@ -44,8 +43,7 @@ class WvrManager : public device::mojom::XRPresentationProvider,
 
   ~WvrManager() override;
 
-  void InitializeGl(ui::WindowAndroid* root_window,
-                    const gfx::Size& frame_size,
+  void InitializeGl(const gfx::Size& frame_size,
                     base::OnceClosure callback);
 
   // XRFrameDataProvider

--- a/wolvic/java/org/chromium/wolvic/VRManager.java
+++ b/wolvic/java/org/chromium/wolvic/VRManager.java
@@ -20,6 +20,7 @@ public class VRManager {
     }
 
     @AnyThread
+    @SuppressWarnings("NoSynchronizedMethodCheck")
     public static synchronized void setExternalContext(final long externalContext) {
         mExternalContext = externalContext;
     }

--- a/wolvic/java/org/chromium/wolvic/WVRSurfaceTexture.java
+++ b/wolvic/java/org/chromium/wolvic/WVRSurfaceTexture.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
     private int mTexName;
 
     private AtomicInteger mUseCount;
-    private boolean mIsLocked = false;
 
     @CalledByNative
     private static WVRSurfaceTexture create(long handle, SurfaceTexture surfaceTexture) {


### PR DESCRIPTION
Fixed some build errors when compiling after cleanup
ex) warning: [NoSynchronizedMethodCheck] Used synchronized modifier in public method
       warning: [NoRedundantFieldInit] Do not explicitly initialize a non-final field with a default value
      warning: unused member