### PR TITLE
Fix no frame issue when reaching a maximum value of frame ID

### DIFF
--- a/wolvic/browser/vr/wvr_device.cc
+++ b/wolvic/browser/vr/wvr_device.cc
@@ -119,15 +119,17 @@ void WvrDevice::OnWvrGlInitializationComplete(
       &WvrManager::StartWebXRPresentation,
       wvr_thread_->GetWvrManager()->GetWeakPtr(), std::move(options),
       CreateMainThreadCallback(
-          base::BindOnce(&WvrDevice::OnStartPresentResult, GetWeakPtr()))));
+          base::BindOnce(&WvrDevice::OnStartPresenting, GetWeakPtr())),
+      CreateMainThreadCallback(base::BindOnce(
+          &WvrDevice::OnStopPresenting, GetWeakPtr(), base::NullCallback()))));
 }
 
-void WvrDevice::OnStartPresentResult(device::mojom::XRSessionPtr session) {
+void WvrDevice::OnStartPresenting(device::mojom::XRSessionPtr session) {
   DCHECK(IsOnMainThread());
   DCHECK(pending_request_session_callback_);
 
   // Set HasExclusiveSession status to true. This lasts until OnSessionEnded.
-  OnStartPresenting();
+  VRDeviceBase::OnStartPresenting();
 
   DCHECK(!exclusive_controller_receiver_.is_bound());
 
@@ -170,6 +172,7 @@ void WvrDevice::OnStopPresenting(
   DCHECK(IsOnMainThread());
   OnExitPresent();
   exclusive_controller_receiver_.reset();
+  wvr_thread_ = nullptr;
 
   if (on_completed)
     std::move(on_completed).Run();

--- a/wolvic/browser/vr/wvr_device.h
+++ b/wolvic/browser/vr/wvr_device.h
@@ -59,7 +59,7 @@ class WvrDevice : public device::VRDeviceBase,
   void OnWvrThreadReady(device::mojom::XRRuntimeSessionOptionsPtr options);
   void OnWvrGlInitializationComplete(
       device::mojom::XRRuntimeSessionOptionsPtr options);
-  void OnStartPresentResult(device::mojom::XRSessionPtr session);
+  void OnStartPresenting(device::mojom::XRSessionPtr session);
 
   // XRSessionController
   void SetFrameDataRestricted(bool restricted) override;

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -27,6 +27,8 @@ namespace wolvic {
 
 namespace {
 
+const int64_t kFrameTimeOutMilliseconds = 10;
+
 void WvrMatToTransform(const float in[16], gfx::Transform* out) {
   *out = gfx::Transform::RowMajor(in[0], in[1], in[2], in[3], in[4], in[5],
                                   in[6], in[7], in[8], in[9], in[10], in[11],
@@ -305,19 +307,23 @@ void WvrManager::OnWebXrFrameAvailable() {
   if (!webxr_frame_timeout_closure_.IsCancelled())
     webxr_frame_timeout_closure_.Cancel();
 
-  // Frame should be locked. Unlock it.
-  DCHECK(webxr_->GetProcessingFrame()->state_locked);
-  webxr_->GetProcessingFrame()->state_locked = false;
+  // The processing frame would be empty when this method is called again from
+  // Android system after OnWebXrTimedOut.
+  if (webxr_->HaveProcessingFrame()) {
+    // Frame should be locked. Unlock it.
+    DCHECK(webxr_->GetProcessingFrame()->state_locked);
+    webxr_->GetProcessingFrame()->state_locked = false;
 
-  if (!SubmitFrameInternal(webxr_->GetProcessingFrame()->index))
-    return;
+    if (!SubmitFrameInternal(webxr_->GetProcessingFrame()->index))
+      return;
+
+    if (webxr_->HaveRenderingFrame())
+      webxr_->EndFrameRendering();
+    webxr_->TransitionFrameProcessingToRendering();
+  }
 
   // Renderer is waiting for the previous frame to render, unblock it now.
   submit_client_->OnSubmitFrameRendered();
-
-  if (webxr_->HaveRenderingFrame())
-    webxr_->EndFrameRendering();
-  webxr_->TransitionFrameProcessingToRendering();
 
   TryStartAnimatingFrame();
 }
@@ -491,15 +497,21 @@ bool WvrManager::SubmitFrameInternal(int16_t frame_index) {
     externalRect.width = 0.5f;
     externalRect.height = 1.0f;
   }
+
+  last_frame_index_ = frame_index;
   PushState(true);
   PullState([this]() {
-    return (system_state_.displayState.lastSubmittedFrameId >=
+    return (system_state_.displayState.lastSubmittedFrameId ==
             last_frame_index_) ||
            system_state_.displayState.suppressFrames ||
            !system_state_.displayState.isConnected;
   });
 
-  last_frame_index_ = system_state_.displayState.lastSubmittedFrameId;
+  // Avoid racing texture between processing in chromium and consuming in
+  // wolvic.
+  layer.textureHandle = 0;
+  PushState(true);
+
   return true;
 }
 
@@ -561,7 +573,7 @@ void WvrManager::ProcessFrameFromMailbox(int16_t frame_index,
 
   task_runner_->PostDelayedTask(FROM_HERE,
                                 webxr_frame_timeout_closure_.callback(),
-                                base::Milliseconds(100));
+                                base::Milliseconds(kFrameTimeOutMilliseconds));
 }
 
 void WvrManager::SubmitFrameDrawnIntoTexture(int16_t frame_index,

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -107,10 +107,18 @@ std::vector<device::mojom::XRViewPtr> CreateViews(
   return views;
 }
 
+int32_t GetNextTextureHandleId() {
+  static int32_t s_next_texture_handle_id = 0;
+  if (s_next_texture_handle_id == std::numeric_limits<int32_t>::max())
+    s_next_texture_handle_id = 0;
+  return ++s_next_texture_handle_id;
+}
+
 }  // namespace
 
 WvrManager::WvrManager()
-    : task_runner_(base::SingleThreadTaskRunner::GetCurrentDefault()),
+    : texture_handle_id_(GetNextTextureHandleId()),
+      task_runner_(base::SingleThreadTaskRunner::GetCurrentDefault()),
       webxr_(std::make_unique<device::WebXrPresentationState>()) {
   JNIEnv* env = base::android::AttachCurrentThread();
   shmem_ = reinterpret_cast<mozilla::gfx::VRExternalShmem*>(
@@ -123,6 +131,11 @@ WvrManager::~WvrManager() {
   ClosePresentationBindings();
   ExitWebXRPresentation(base::NullCallback());
   webxr_->EndPresentation();
+
+  if (j_surface_texture_) {
+    JNIEnv* env = base::android::AttachCurrentThread();
+    Java_WVRSurfaceTexture_release(env, j_surface_texture_);
+  }
 }
 
 void WvrManager::InitializeGl(const gfx::Size& frame_size,
@@ -170,8 +183,11 @@ void WvrManager::InitializeGl(const gfx::Size& frame_size,
 
 void WvrManager::StartWebXRPresentation(
     device::mojom::XRRuntimeSessionOptionsPtr options,
-    base::OnceCallback<void(device::mojom::XRSessionPtr)> callback) {
+    base::OnceCallback<void(device::mojom::XRSessionPtr)> callback,
+    base::OnceClosure exit_callback) {
   DCHECK(IsOnWvrThread());
+
+  exit_vr_callback_ = std::move(exit_callback);
 
   // Indicate that we are ready to start immersive mode
   browser_state_.presentationActive = true;
@@ -184,6 +200,8 @@ void WvrManager::StartWebXRPresentation(
            system_state_.displayState.isConnected;
   });
 
+  presenting_generation_ = system_state_.displayState.presentingGeneration;
+
   ConnectPresentingService(std::move(options), std::move(callback));
 }
 
@@ -191,9 +209,9 @@ void WvrManager::ExitWebXRPresentation(base::OnceClosure callback) {
   DCHECK(IsOnWvrThread());
 
   browser_state_.presentationActive = false;
-  PushState();
-
-  PullState([&]() { return !system_state_.displayState.isConnected; });
+  browser_state_.layerState[0].type =
+      mozilla::gfx::VRLayerType::LayerType_None;
+  PushState(true);
 
   if (callback)
     std::move(callback).Run();
@@ -213,9 +231,8 @@ void WvrManager::CreateOrResizeWebXrSurface(const gfx::Size& size) {
 
   if (!j_surface_texture_) {
     JNIEnv* env = base::android::AttachCurrentThread();
-    j_surface_texture_ =
-        Java_WVRSurfaceTexture_create(env, texture_id_,
-                                      surface_texture_->j_surface_texture());
+    j_surface_texture_ = Java_WVRSurfaceTexture_create(
+        env, texture_handle_id_, surface_texture_->j_surface_texture());
   }
 
   surface_size_ = size;
@@ -334,6 +351,12 @@ void WvrManager::OnWebXrTimedOut() {
 }
 
 void WvrManager::ClosePresentationBindings() {
+  if (!webxr_frame_timeout_closure_.IsCancelled())
+    webxr_frame_timeout_closure_.Cancel();
+
+  if (!get_frame_data_callback_.is_null())
+    std::move(get_frame_data_callback_).Run(nullptr);
+
   submit_client_.reset();
   presentation_receiver_.reset();
   frame_data_receiver_.reset();
@@ -417,6 +440,10 @@ bool WvrManager::CanStartNewAnimatingFrame() {
     return false;
   }
 
+  if (get_frame_data_callback_.is_null()) {
+    return false;
+  }
+
   return true;
 }
 
@@ -481,11 +508,22 @@ void WvrManager::SetInputSourceButtonListener(
 bool WvrManager::SubmitFrameInternal(int16_t frame_index) {
   DCHECK(IsOnWvrThread());
 
+  // Force exit WebXR before pushing the frame if the presenting generation is
+  // changed by stopping presenting in Wolvic.
+  if (presenting_generation_ != system_state_.displayState.presentingGeneration) {
+    if (!get_frame_data_callback_.is_null())
+      std::move(get_frame_data_callback_).Run(nullptr);
+
+    if (exit_vr_callback_)
+      std::move(exit_vr_callback_).Run();
+    return false;
+  }
+
   auto& layer = browser_state_.layerState[0].layer_stereo_immersive;
   layer.frameId = frame_index;
   layer.textureSize.width = surface_size_.width();
   layer.textureSize.height = surface_size_.height();
-  layer.textureHandle = texture_id_;
+  layer.textureHandle = texture_handle_id_;
 
   // for (auto& view: views) {
   for (int i = 0; i < 2; ++i) {

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -27,7 +27,7 @@ namespace wolvic {
 
 namespace {
 
-const int64_t kFrameTimeOutMilliseconds = 10;
+const int64_t kFrameTimeOutMilliseconds = 1000;
 
 void WvrMatToTransform(const float in[16], gfx::Transform* out) {
   *out = gfx::Transform::RowMajor(in[0], in[1], in[2], in[3], in[4], in[5],

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -81,7 +81,8 @@ class WvrManager : public device::mojom::XRPresentationProvider,
 
   void StartWebXRPresentation(
       device::mojom::XRRuntimeSessionOptionsPtr options,
-      base::OnceCallback<void(device::mojom::XRSessionPtr)> callback);
+      base::OnceCallback<void(device::mojom::XRSessionPtr)> callback,
+      base::OnceClosure exit_callback);
   void ExitWebXRPresentation(base::OnceClosure callback);
 
  private:
@@ -118,6 +119,7 @@ class WvrManager : public device::mojom::XRPresentationProvider,
 
   // samplerExternalOES texture data for WebVR content image.
   GLuint texture_id_ = 0;
+  int32_t texture_handle_id_;
   scoped_refptr<gl::GLSurface> surface_;
   scoped_refptr<gl::GLContext> context_;
 
@@ -147,6 +149,10 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   std::unique_ptr<device::MailboxToSurfaceBridge> mailbox_bridge_;
 
   base::CancelableOnceClosure webxr_frame_timeout_closure_;
+
+  base::OnceClosure exit_vr_callback_;
+
+  uint32_t presenting_generation_;
 
   base::WeakPtrFactory<WvrManager> weak_ptr_factory_{this};
 };

--- a/wolvic/java/org/chromium/wolvic/WVRSurfaceTexture.java
+++ b/wolvic/java/org/chromium/wolvic/WVRSurfaceTexture.java
@@ -75,6 +75,7 @@ import java.util.concurrent.atomic.AtomicInteger;
         }
     }
 
+    @CalledByNative
     public synchronized void release() {
         try {
             mSurfaceTexture.release();


### PR DESCRIPTION
- Fixed the white flashing issue
  When sharing textures, the following order should be ensured.
```
  Processing (write texture) in the browser
  -> The frame-available callback in the browser
  -> consuming (read texture) in Wolvic
      StartFrame(call UpdateTexImage)
      -> Draw
      -> EndFrame (Call ReleaseTexImage)
```
   Wolvic accesses the last texture every tick(=vsync) even if we don't set the next frame id. Then, it can cause to update/release of texture in Wolvic when the browser is processing the texture on another thread, which can be broken the above sequence. This will cause the empty buffer frame in texture and occur a white flashing issue.

   Reset the texture name as zero after finishing the frame to avoid the racing between processing the texture in chromium and consuming it in Wolvic.

- Fixed no frame issue when reaching a maximum value of frame ID
  Chromium has a maximum value of frame ID of 255(uint8), and when recycling frame id to zero, processing the frame gets stuck.

- Reduced the time-out value to 10ms
  If the texture conflicts, the callback could not be called in time. We reduce the timer's time so that the next frame is handled shortly.
