### PR TITLE
Chromium: Implement basic WebXR input support

### DIFF
--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -153,6 +153,7 @@ enum class VRControllerType : uint8_t {
   PicoGaze,
   PicoG2,
   PicoNeo2,
+  Pico4,
   _end
 };
 

--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -7,6 +7,8 @@
 #ifndef GFX_VR_EXTERNAL_API_H
 #define GFX_VR_EXTERNAL_API_H
 
+#define __ANDROID__ 1
+
 #define GFX_VR_EIGHTCC(c1, c2, c3, c4, c5, c6, c7, c8)                  \
   ((uint64_t)(c1) << 56 | (uint64_t)(c2) << 48 | (uint64_t)(c3) << 40 | \
    (uint64_t)(c4) << 32 | (uint64_t)(c5) << 24 | (uint64_t)(c6) << 16 | \
@@ -151,7 +153,6 @@ enum class VRControllerType : uint8_t {
   PicoGaze,
   PicoG2,
   PicoNeo2,
-  Pico4,
   _end
 };
 
@@ -427,11 +428,6 @@ struct VRControllerState {
   // to the controllers' pose in target ray space:
   // https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace
   VRPose targetRayPose;
-
-  // When Cap_Orientation is set in flags, targetRayOrientation corresponds
-  // to the orientation of the target ray (origin of the ray is determined by
-  // the controller position). Only used by the Chromium backend.
-  float targetRayOrientation[4];
 
   bool isPositionValid;
   bool isOrientationValid;

--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -7,8 +7,6 @@
 #ifndef GFX_VR_EXTERNAL_API_H
 #define GFX_VR_EXTERNAL_API_H
 
-#define __ANDROID__ 1
-
 #define GFX_VR_EIGHTCC(c1, c2, c3, c4, c5, c6, c7, c8)                  \
   ((uint64_t)(c1) << 56 | (uint64_t)(c2) << 48 | (uint64_t)(c3) << 40 | \
    (uint64_t)(c4) << 32 | (uint64_t)(c5) << 24 | (uint64_t)(c6) << 16 | \
@@ -153,6 +151,7 @@ enum class VRControllerType : uint8_t {
   PicoGaze,
   PicoG2,
   PicoNeo2,
+  Pico4,
   _end
 };
 
@@ -428,6 +427,11 @@ struct VRControllerState {
   // to the controllers' pose in target ray space:
   // https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace
   VRPose targetRayPose;
+
+  // When Cap_Orientation is set in flags, targetRayOrientation corresponds
+  // to the orientation of the target ray (origin of the ray is determined by
+  // the controller position). Only used by the Chromium backend.
+  float targetRayOrientation[4];
 
   bool isPositionValid;
   bool isOrientationValid;

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -373,14 +373,14 @@ WvrManager::GetInputSourceState() {
 
   for (uint32_t i = 0; i < mozilla::gfx::kVRControllerMaxCount; ++i) {
     const auto& controller = system_state_.controllerState[i];
-    // TODO : Update the structure
-    // if (!controller.connected)
-    //     continue;
+    if (controller.type == mozilla::gfx::VRControllerType::_empty)
+      continue;
 
     device::mojom::XRInputSourceStatePtr input_source =
         device::mojom::XRInputSourceState::New();
 
-    input_source->source_id = i;
+    // The source_id == 0 is not supported, so we're using a 1-based id here.
+    input_source->source_id = i + 1;
     input_source->primary_input_pressed = controller.buttonPressed;
     input_source->primary_input_clicked = controller.buttonTouched;
 
@@ -403,15 +403,24 @@ WvrManager::GetInputSourceState() {
         controller.hand == mozilla::gfx::ControllerHand::Left
             ? device::mojom::XRHandedness::LEFT
             : device::mojom::XRHandedness::RIGHT;
-
     // TODO: Get from external
     input_source->description->profiles = {
         "oculus-touch-v3", "oculus-touch-v2", "oculus-touch",
         "generic-trigger-squeeze-thumbstick"};
 
-    gfx::Transform input_from_pointer;
-    WvrMatToTransform(controller.axisValue, &input_from_pointer);
-    input_source->description->input_from_pointer = input_from_pointer;
+    input_source->gamepad = device::Gamepad();
+    input_source->gamepad->buttons_length = controller.numButtons;
+    input_source->gamepad->hand =
+        controller.hand == mozilla::gfx::ControllerHand::Left
+            ? device::GamepadHand::kLeft
+            : device::GamepadHand::kRight;
+    for (uint32_t j = 0; j < controller.numButtons; ++j) {
+      input_source->gamepad->buttons[j].pressed =
+          controller.buttonPressed & (1 << j);
+      input_source->gamepad->buttons[j].touched =
+          controller.buttonTouched & (1 << j);
+      input_source->gamepad->buttons[j].value = controller.triggerValue[j];
+    }
 
     auto supportsControllerFlag =
         [&controller](mozilla::gfx::ControllerCapabilityFlags flag) {
@@ -424,7 +433,20 @@ WvrManager::GetInputSourceState() {
         supportsControllerFlag(
             mozilla::gfx::ControllerCapabilityFlags::Cap_PositionEmulated);
 
-    input_source->mojo_from_input = WvrPoseToTransform(&controller.pose);
+    if (supportsControllerFlag(
+            mozilla::gfx::ControllerCapabilityFlags::Cap_Orientation)) {
+      input_source->description->input_from_pointer =
+          WvrPoseToTransform(&controller.targetRayPose);
+    }
+
+    if (supportsControllerFlag(
+            mozilla::gfx::ControllerCapabilityFlags::Cap_Position) ||
+        supportsControllerFlag(
+            mozilla::gfx::ControllerCapabilityFlags::Cap_PositionEmulated) ||
+        supportsControllerFlag(
+            mozilla::gfx::ControllerCapabilityFlags::Cap_GripSpacePosition)) {
+      input_source->mojo_from_input = WvrPoseToTransform(&controller.pose);
+    }
 
     input_sources.push_back(std::move(input_source));
   }
@@ -478,8 +500,7 @@ void WvrManager::TryStartAnimatingFrame() {
 
   frame_data->mojo_space_reset = true;
 
-  // TODO : Fix the crash issue
-  // frame_data->input_state = GetInputSourceState();
+  frame_data->input_state = GetInputSourceState();
 
   frame_data->mojo_from_viewer =
       PoseToVRPosePtr(&system_state_.sensorState.pose);  // std::move(pose);

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -49,6 +49,12 @@ gfx::Transform WvrPoseToTransform(const mozilla::gfx::VRPose* pose) {
   return gfx::Transform::Compose(decomp);
 }
 
+gfx::Transform WvrOrientationToTransform(const float orientation[4]) {
+  gfx::Quaternion quaternion(orientation[0], orientation[1], orientation[2],
+                             orientation[3]);
+  return gfx::Transform(quaternion);
+}
+
 device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
   device::mojom::VRPosePtr pose = device::mojom::VRPose::New();
   pose->position = gfx::Point3F(p->position[0], p->position[1], p->position[2]);
@@ -464,7 +470,7 @@ WvrManager::GetInputSourceState() {
     if (supportsControllerFlag(
             mozilla::gfx::ControllerCapabilityFlags::Cap_Orientation)) {
       input_source->description->input_from_pointer =
-          WvrPoseToTransform(&controller.targetRayPose);
+          WvrOrientationToTransform(controller.targetRayOrientation);
     }
 
     if (supportsControllerFlag(

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -57,6 +57,43 @@ device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
   return pose;
 }
 
+device::GamepadHand ToGamepadHand(mozilla::gfx::ControllerHand hand) {
+  using mozilla::gfx::ControllerHand;
+
+  switch (hand) {
+    case ControllerHand::Left:
+      return device::GamepadHand::kLeft;
+    case ControllerHand::Right:
+      return device::GamepadHand::kRight;
+    case ControllerHand::_empty:
+    case ControllerHand::EndGuard_:
+      DCHECK(false) << "Unexpected ControllerHand value: "
+                    << static_cast<uint8_t>(hand);
+      return device::GamepadHand::kNone;
+  }
+}
+
+device::Gamepad ToGamepad(const mozilla::gfx::VRControllerState& controller) {
+  device::Gamepad gamepad;
+  gamepad.hand = ToGamepadHand(controller.hand);
+
+  size_t num_buttons = controller.numButtons;
+  if (num_buttons > device::Gamepad::kButtonsLengthCap) {
+    num_buttons = device::Gamepad::kButtonsLengthCap;
+    DLOG(WARNING) << "Controller has too many buttons, truncating to "
+                  << num_buttons;
+  }
+
+  gamepad.buttons_length = num_buttons;
+  for (uint32_t i = 0; i < controller.numButtons; ++i) {
+    gamepad.buttons[i].pressed = controller.buttonPressed & (1 << i);
+    gamepad.buttons[i].touched = controller.buttonTouched & (1 << i);
+    gamepad.buttons[i].value = controller.triggerValue[i];
+  }
+
+  return gamepad;
+}
+
 device::mojom::XRViewPtr CreateView(
     mozilla::gfx::VRDisplayState::Eye eye,
     const mozilla::gfx::VRDisplayState& display_state,
@@ -405,24 +442,13 @@ WvrManager::GetInputSourceState() {
         controller.hand == mozilla::gfx::ControllerHand::Left
             ? device::mojom::XRHandedness::LEFT
             : device::mojom::XRHandedness::RIGHT;
+
     // TODO: Get from external
     input_source->description->profiles = {
         "oculus-touch-v3", "oculus-touch-v2", "oculus-touch",
         "generic-trigger-squeeze-thumbstick"};
 
-    input_source->gamepad = device::Gamepad();
-    input_source->gamepad->buttons_length = controller.numButtons;
-    input_source->gamepad->hand =
-        controller.hand == mozilla::gfx::ControllerHand::Left
-            ? device::GamepadHand::kLeft
-            : device::GamepadHand::kRight;
-    for (uint32_t j = 0; j < controller.numButtons; ++j) {
-      input_source->gamepad->buttons[j].pressed =
-          controller.buttonPressed & (1 << j);
-      input_source->gamepad->buttons[j].touched =
-          controller.buttonTouched & (1 << j);
-      input_source->gamepad->buttons[j].value = controller.triggerValue[j];
-    }
+    input_source->gamepad = ToGamepad(controller);
 
     auto supportsControllerFlag =
         [&controller](mozilla::gfx::ControllerCapabilityFlags flag) {

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -379,7 +379,9 @@ WvrManager::GetInputSourceState() {
     device::mojom::XRInputSourceStatePtr input_source =
         device::mojom::XRInputSourceState::New();
 
-    // The source_id == 0 is not supported, so we're using a 1-based id here.
+    // ID 0 will cause a DCHECK in the hash table used on the blink side.
+    // To ensure that we don't have any collisions with other ids, increment
+    // all of the ids by one.
     input_source->source_id = i + 1;
     input_source->primary_input_pressed = controller.buttonPressed;
     input_source->primary_input_clicked = controller.buttonTouched;

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -49,12 +49,6 @@ gfx::Transform WvrPoseToTransform(const mozilla::gfx::VRPose* pose) {
   return gfx::Transform::Compose(decomp);
 }
 
-gfx::Transform WvrOrientationToTransform(const float orientation[4]) {
-  gfx::Quaternion quaternion(orientation[0], orientation[1], orientation[2],
-                             orientation[3]);
-  return gfx::Transform(quaternion);
-}
-
 device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
   device::mojom::VRPosePtr pose = device::mojom::VRPose::New();
   pose->position = gfx::Point3F(p->position[0], p->position[1], p->position[2]);
@@ -470,7 +464,7 @@ WvrManager::GetInputSourceState() {
     if (supportsControllerFlag(
             mozilla::gfx::ControllerCapabilityFlags::Cap_Orientation)) {
       input_source->description->input_from_pointer =
-          WvrOrientationToTransform(controller.targetRayOrientation);
+          WvrPoseToTransform(&controller.targetRayPose);
     }
 
     if (supportsControllerFlag(


### PR DESCRIPTION
This change implements basic WebXR input support, including controller position, orientation and pressed buttons.

This was tested on Oculus Quest 2 controllers.