### PR TITLE
Implement User Agent settings

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -29,6 +29,9 @@ shared_library("libcontent_native") {
     "../content/shell/browser/shell_platform_delegate_android.cc",
     "../content/shell/common/shell_switches.cc",
     "../content/shell/common/shell_switches.h",
+    "browser/session_settings.cc",
+    "browser/session_settings.h",
+    "browser/session_settings_jni.cc",
     "browser/tab_jni.cc",
     "browser/vr/moz_external_vr.h",
     "browser/vr/wolvic_xr_integration_client.cc",
@@ -185,6 +188,7 @@ jinja_template("content_manifest") {
 
 generate_jni("jni_headers") {
   sources = [
+    "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",
     "java/org/chromium/wolvic/VRManager.java",
     "java/org/chromium/wolvic/WVRSurfaceTexture.java",
@@ -193,6 +197,7 @@ generate_jni("jni_headers") {
 
 android_library("wolvic_java") {
   sources = [
+    "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",
     "java/org/chromium/wolvic/TabCompositorView.java",
     "java/org/chromium/wolvic/VRManager.java",

--- a/wolvic/browser/session_settings.cc
+++ b/wolvic/browser/session_settings.cc
@@ -1,0 +1,48 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/browser/session_settings.h"
+
+#include "base/check.h"
+
+namespace content {
+
+namespace {
+
+SessionSettings* g_instance = nullptr;
+
+}  // namespace
+
+SessionSettings::SessionSettings() {
+  DCHECK(!g_instance);
+  g_instance = this;
+}
+
+SessionSettings::~SessionSettings() {
+  g_instance = nullptr;
+}
+
+SessionSettings* SessionSettings::Get() {
+  DCHECK(g_instance);
+  return g_instance;
+}
+
+void SessionSettings::SetUserAgentMode(UserAgentMode value) {
+  user_agent_mode_ = value;
+}
+
+UserAgentMode SessionSettings::GetUserAgentMode() {
+  return user_agent_mode_;
+}
+
+void SessionSettings::SetUserAgentOverride(
+    const absl::optional<std::string>& value) {
+  user_agent_override_ = value;
+}
+
+absl::optional<std::string> SessionSettings::GetUserAgentOverride() {
+  return user_agent_override_;
+}
+
+}  // namespace content

--- a/wolvic/browser/session_settings.cc
+++ b/wolvic/browser/session_settings.cc
@@ -6,7 +6,7 @@
 
 #include "base/check.h"
 
-namespace content {
+namespace wolvic {
 
 namespace {
 
@@ -45,4 +45,4 @@ absl::optional<std::string> SessionSettings::GetUserAgentOverride() {
   return user_agent_override_;
 }
 
-}  // namespace content
+}  // namespace wolvic

--- a/wolvic/browser/session_settings.cc
+++ b/wolvic/browser/session_settings.cc
@@ -32,7 +32,7 @@ void SessionSettings::SetUserAgentMode(UserAgentMode value) {
   user_agent_mode_ = value;
 }
 
-SessionSettings::UserAgentMode SessionSettings::GetUserAgentMode() {
+SessionSettings::UserAgentMode SessionSettings::GetUserAgentMode() const {
   return user_agent_mode_;
 }
 
@@ -41,7 +41,7 @@ void SessionSettings::SetUserAgentOverride(
   user_agent_override_ = value;
 }
 
-absl::optional<std::string> SessionSettings::GetUserAgentOverride() {
+absl::optional<std::string> SessionSettings::GetUserAgentOverride() const {
   return user_agent_override_;
 }
 

--- a/wolvic/browser/session_settings.cc
+++ b/wolvic/browser/session_settings.cc
@@ -32,7 +32,7 @@ void SessionSettings::SetUserAgentMode(UserAgentMode value) {
   user_agent_mode_ = value;
 }
 
-UserAgentMode SessionSettings::GetUserAgentMode() {
+SessionSettings::UserAgentMode SessionSettings::GetUserAgentMode() {
   return user_agent_mode_;
 }
 

--- a/wolvic/browser/session_settings.h
+++ b/wolvic/browser/session_settings.h
@@ -12,6 +12,7 @@
 namespace wolvic {
 
 enum class UserAgentMode {
+  // values have to be synchronized with SessionSettings.java
   kMobile = 0,
   kDesktop = 1,
   kMobileVR = 2,

--- a/wolvic/browser/session_settings.h
+++ b/wolvic/browser/session_settings.h
@@ -9,7 +9,7 @@
 
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
-namespace content {
+namespace wolvic {
 
 enum class UserAgentMode {
   kMobile = 0,
@@ -38,6 +38,6 @@ class SessionSettings {
   absl::optional<std::string> user_agent_override_;
 };
 
-}  // namespace content
+}  // namespace wolvic
 
 #endif  // WOLVIC_BROWSER_SESSION_SETTINGS_H_

--- a/wolvic/browser/session_settings.h
+++ b/wolvic/browser/session_settings.h
@@ -1,0 +1,43 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WOLVIC_BROWSER_SESSION_SETTINGS_H_
+#define WOLVIC_BROWSER_SESSION_SETTINGS_H_
+
+#include <string>
+
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
+namespace content {
+
+enum class UserAgentMode {
+  kMobile = 0,
+  kDesktop = 1,
+  kMobileVR = 2,
+};
+
+// A singleton class holding all settings for the current session.
+class SessionSettings {
+ public:
+  explicit SessionSettings();
+  SessionSettings(const SessionSettings&) = delete;
+  SessionSettings& operator=(const SessionSettings&) = delete;
+  ~SessionSettings();
+
+  // Returns the singleton instance.
+  static SessionSettings* Get();
+
+  void SetUserAgentMode(UserAgentMode value);
+  UserAgentMode GetUserAgentMode();
+  void SetUserAgentOverride(const absl::optional<std::string>& value);
+  absl::optional<std::string> GetUserAgentOverride();
+
+ private:
+  UserAgentMode user_agent_mode_ = UserAgentMode::kMobile;
+  absl::optional<std::string> user_agent_override_;
+};
+
+}  // namespace content
+
+#endif  // WOLVIC_BROWSER_SESSION_SETTINGS_H_

--- a/wolvic/browser/session_settings.h
+++ b/wolvic/browser/session_settings.h
@@ -30,9 +30,9 @@ class SessionSettings {
   static SessionSettings* Get();
 
   void SetUserAgentMode(UserAgentMode value);
-  UserAgentMode GetUserAgentMode();
+  UserAgentMode GetUserAgentMode() const;
   void SetUserAgentOverride(const absl::optional<std::string>& value);
-  absl::optional<std::string> GetUserAgentOverride();
+  absl::optional<std::string> GetUserAgentOverride() const;
 
  private:
   UserAgentMode user_agent_mode_ = UserAgentMode::kMobile;

--- a/wolvic/browser/session_settings.h
+++ b/wolvic/browser/session_settings.h
@@ -11,16 +11,16 @@
 
 namespace wolvic {
 
-enum class UserAgentMode {
-  // values have to be synchronized with SessionSettings.java
-  kMobile = 0,
-  kDesktop = 1,
-  kMobileVR = 2,
-};
-
 // A singleton class holding all settings for the current session.
 class SessionSettings {
  public:
+  enum class UserAgentMode {
+    // values have to be synchronized with SessionSettings.java
+    kMobile = 0,
+    kDesktop = 1,
+    kMobileVR = 2,
+  };
+
   explicit SessionSettings();
   SessionSettings(const SessionSettings&) = delete;
   SessionSettings& operator=(const SessionSettings&) = delete;

--- a/wolvic/browser/session_settings_jni.cc
+++ b/wolvic/browser/session_settings_jni.cc
@@ -1,0 +1,45 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/jni_headers/SessionSettings_jni.h"
+
+#include "base/android/jni_string.h"
+#include "wolvic/browser/session_settings.h"
+
+using base::android::JavaParamRef;
+using base::android::ScopedJavaLocalRef;
+
+namespace content {
+
+void JNI_SessionSettings_SetUserAgentMode(JNIEnv* env, jint value) {
+  SessionSettings::Get()->SetUserAgentMode(static_cast<UserAgentMode>(value));
+}
+
+jint JNI_SessionSettings_GetUserAgentMode(JNIEnv* env) {
+  return static_cast<jint>(SessionSettings::Get()->GetUserAgentMode());
+}
+
+void JNI_SessionSettings_SetUserAgentOverride(
+    JNIEnv*,
+    const JavaParamRef<jstring>& value) {
+  auto* settings = SessionSettings::Get();
+  if (value) {
+    settings->SetUserAgentOverride(
+        base::android::ConvertJavaStringToUTF8(value));
+  } else {
+    settings->SetUserAgentOverride(absl::nullopt);
+  }
+}
+
+ScopedJavaLocalRef<jstring> JNI_SessionSettings_GetUserAgentOverride(
+    JNIEnv* env) {
+  auto userAgentOverride = SessionSettings::Get()->GetUserAgentOverride();
+  if (!userAgentOverride) {
+    return ScopedJavaLocalRef<jstring>();
+  }
+
+  return base::android::ConvertUTF8ToJavaString(env, *userAgentOverride);
+}
+
+}  // namespace content

--- a/wolvic/browser/session_settings_jni.cc
+++ b/wolvic/browser/session_settings_jni.cc
@@ -10,7 +10,7 @@
 using base::android::JavaParamRef;
 using base::android::ScopedJavaLocalRef;
 
-namespace content {
+namespace wolvic {
 
 void JNI_SessionSettings_SetUserAgentMode(JNIEnv* env, jint value) {
   SessionSettings::Get()->SetUserAgentMode(static_cast<UserAgentMode>(value));

--- a/wolvic/browser/session_settings_jni.cc
+++ b/wolvic/browser/session_settings_jni.cc
@@ -13,7 +13,8 @@ using base::android::ScopedJavaLocalRef;
 namespace wolvic {
 
 void JNI_SessionSettings_SetUserAgentMode(JNIEnv* env, jint value) {
-  SessionSettings::Get()->SetUserAgentMode(static_cast<UserAgentMode>(value));
+  SessionSettings::Get()->SetUserAgentMode(
+      static_cast<SessionSettings::UserAgentMode>(value));
 }
 
 jint JNI_SessionSettings_GetUserAgentMode(JNIEnv* env) {
@@ -42,4 +43,4 @@ ScopedJavaLocalRef<jstring> JNI_SessionSettings_GetUserAgentOverride(
   return base::android::ConvertUTF8ToJavaString(env, *userAgentOverride);
 }
 
-}  // namespace content
+}  // namespace wolvic

--- a/wolvic/java/org/chromium/wolvic/SessionSettings.java
+++ b/wolvic/java/org/chromium/wolvic/SessionSettings.java
@@ -24,11 +24,11 @@ public class SessionSettings {
             this.value = value;
         }
 
-        public int getValue() {
+        private int getValue() {
             return value;
         }
 
-        public static UserAgentMode fromValue(int value) {
+        private static UserAgentMode fromValue(int value) {
             return modes[value];
         }
     };

--- a/wolvic/java/org/chromium/wolvic/SessionSettings.java
+++ b/wolvic/java/org/chromium/wolvic/SessionSettings.java
@@ -11,14 +11,36 @@ import org.chromium.base.annotations.NativeMethods;
 
 @JNINamespace("wolvic")
 public class SessionSettings {
+    public enum UserAgentMode {
+        // values have to be synchronized with session_settings.h
+        MOBILE(0),
+        DESKTOP(1),
+        MOBILE_VR(2);
+
+        private static final UserAgentMode[] modes = UserAgentMode.values();
+        private final int value;
+
+        private UserAgentMode(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public static UserAgentMode fromValue(int value) {
+            return modes[value];
+        }
+    };
+
     public SessionSettings() {}
 
-    public void setUserAgentMode(int value) {
-        SessionSettingsJni.get().setUserAgentMode(value);
+    public void setUserAgentMode(UserAgentMode mode) {
+        SessionSettingsJni.get().setUserAgentMode(mode.getValue());
     }
 
-    public int getUserAgentMode() {
-        return SessionSettingsJni.get().getUserAgentMode();
+    public UserAgentMode getUserAgentMode() {
+        return UserAgentMode.fromValue(SessionSettingsJni.get().getUserAgentMode());
     }
 
     public void setUserAgentOverride(@Nullable String value) {

--- a/wolvic/java/org/chromium/wolvic/SessionSettings.java
+++ b/wolvic/java/org/chromium/wolvic/SessionSettings.java
@@ -1,0 +1,41 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import androidx.annotation.Nullable;
+
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+
+@JNINamespace("content")
+public class SessionSettings {
+    public SessionSettings() {}
+
+    public void setUserAgentMode(int value) {
+        SessionSettingsJni.get().setUserAgentMode(value);
+    }
+
+    public int getUserAgentMode() {
+        return SessionSettingsJni.get().getUserAgentMode();
+    }
+
+    public void setUserAgentOverride(@Nullable String value) {
+        SessionSettingsJni.get().setUserAgentOverride(value);
+    }
+
+    @Nullable
+    public String getUserAgentOverride() {
+        return SessionSettingsJni.get().getUserAgentOverride();
+    }
+
+    @NativeMethods
+    public interface Natives {
+        void setUserAgentMode(int value);
+        int getUserAgentMode();
+        void setUserAgentOverride(@Nullable String value);
+        @Nullable
+        String getUserAgentOverride();
+    }
+}

--- a/wolvic/java/org/chromium/wolvic/SessionSettings.java
+++ b/wolvic/java/org/chromium/wolvic/SessionSettings.java
@@ -9,7 +9,7 @@ import androidx.annotation.Nullable;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
 
-@JNINamespace("content")
+@JNINamespace("wolvic")
 public class SessionSettings {
     public SessionSettings() {}
 

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -8,6 +8,7 @@
 #include "components/prefs/pref_service.h"
 #include "content/shell/browser/shell.h"
 #include "content/shell/browser/shell_devtools_manager_delegate.h"
+#include "wolvic/browser/session_settings.h"
 #include "wolvic/wolvic_browser_context.h"
 #include "wolvic/wolvic_content_main_delegate.h"
 #include "wolvic/wolvic_main_parts.h"
@@ -17,6 +18,18 @@ namespace content {
 namespace {
 
 WolvicContentBrowserClient* g_instance = nullptr;
+
+// Adds the given platform to the user agent string. For example, if
+// we add "Mobile VR" platform to the following user agent
+// "Mozilla/5.0 (Linux; Android 8.0.0; Quest 2)", the result will be:
+// "Mozilla/5.0 (Linux; Android 8.0.0; Quest 2; Mobile VR)".
+void AddPlatformToUserAgent(const std::string& platform,
+                            std::string* user_agent) {
+  size_t pos = user_agent->find(')');
+  if (pos != std::string::npos) {
+    user_agent->insert(pos, "; " + platform);
+  }
+}
 
 }  // namespace
 
@@ -64,41 +77,39 @@ XrIntegrationClient* WolvicContentBrowserClient::GetXrIntegrationClient() {
 #endif
 
 std::string WolvicContentBrowserClient::GetUserAgent() {
-  return embedder_support::GetUserAgent();
-}
+  auto user_agent_override = SessionSettings::Get()->GetUserAgentOverride();
+  if (user_agent_override)
+    return *user_agent_override;
 
-std::string WolvicContentBrowserClient::GetUserAgentBasedOnPolicy(
-    content::BrowserContext* context) {
-  auto* delegate = WolvicContentMainDelegate::Get();
-
-  const PrefService* prefs = delegate->GetPrefs();
-  embedder_support::ForceMajorVersionToMinorPosition
-      force_major_version_to_minor =
-          embedder_support::GetMajorToMinorFromPrefs(prefs);
-  embedder_support::UserAgentReductionEnterprisePolicyState
-      user_agent_reduction =
-          embedder_support::GetUserAgentReductionFromPrefs(prefs);
-  switch (user_agent_reduction) {
-    case embedder_support::UserAgentReductionEnterprisePolicyState::
-        kForceDisabled:
-      return embedder_support::GetFullUserAgent(force_major_version_to_minor);
-    case embedder_support::UserAgentReductionEnterprisePolicyState::
-        kForceEnabled:
-      return embedder_support::GetReducedUserAgent(
-          force_major_version_to_minor);
-    case embedder_support::UserAgentReductionEnterprisePolicyState::kDefault:
-    default:
-      return embedder_support::GetUserAgent(force_major_version_to_minor,
-                                            user_agent_reduction);
+  std::string user_agent = embedder_support::GetUserAgent();
+  auto user_agent_mode = SessionSettings::Get()->GetUserAgentMode();
+  switch (user_agent_mode) {
+    case UserAgentMode::kMobile:
+      AddPlatformToUserAgent("Mobile", &user_agent);
+      break;
+    case UserAgentMode::kMobileVR:
+      AddPlatformToUserAgent("Mobile VR", &user_agent);
+      break;
+    case UserAgentMode::kDesktop:
+      // do nothing
+      break;
   }
+  return user_agent;
 }
 
-std::string WolvicContentBrowserClient::GetFullUserAgent() {
-  return embedder_support::GetFullUserAgent();
-}
-
-std::string WolvicContentBrowserClient::GetReducedUserAgent() {
-  return embedder_support::GetReducedUserAgent();
+blink::UserAgentMetadata WolvicContentBrowserClient::GetUserAgentMetadata() {
+  auto metadata = embedder_support::GetUserAgentMetadata();
+  auto user_agent_mode = SessionSettings::Get()->GetUserAgentMode();
+  switch (user_agent_mode) {
+    case UserAgentMode::kMobile:
+    case UserAgentMode::kMobileVR:
+      metadata.mobile = true;
+      break;
+    case UserAgentMode::kDesktop:
+      metadata.mobile = false;
+      break;
+  }
+  return metadata;
 }
 
 }  // namespace content

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -24,10 +24,10 @@ WolvicContentBrowserClient* g_instance = nullptr;
 // "Mozilla/5.0 (Linux; Android 8.0.0; Quest 2)", the result will be:
 // "Mozilla/5.0 (Linux; Android 8.0.0; Quest 2; Mobile VR)".
 void AddPlatformToUserAgent(const std::string& platform,
-                            std::string* user_agent) {
-  size_t pos = user_agent->find(')');
+                            std::string& user_agent) {
+  size_t pos = user_agent.find(')');
   if (pos != std::string::npos) {
-    user_agent->insert(pos, "; " + platform);
+    user_agent.insert(pos, "; " + platform);
   }
 }
 
@@ -88,10 +88,10 @@ std::string WolvicContentBrowserClient::GetUserAgent() {
   auto user_agent_mode = wolvic::SessionSettings::Get()->GetUserAgentMode();
   switch (user_agent_mode) {
     case UserAgentMode::kMobile:
-      AddPlatformToUserAgent("Mobile", &user_agent);
+      AddPlatformToUserAgent("Mobile", user_agent);
       break;
     case UserAgentMode::kMobileVR:
-      AddPlatformToUserAgent("Mobile VR", &user_agent);
+      AddPlatformToUserAgent("Mobile VR", user_agent);
       break;
     case UserAgentMode::kDesktop:
       // do nothing

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -77,20 +77,20 @@ XrIntegrationClient* WolvicContentBrowserClient::GetXrIntegrationClient() {
 #endif
 
 std::string WolvicContentBrowserClient::GetUserAgent() {
-  auto user_agent_override = SessionSettings::Get()->GetUserAgentOverride();
+  auto user_agent_override = wolvic::SessionSettings::Get()->GetUserAgentOverride();
   if (user_agent_override)
     return *user_agent_override;
 
   std::string user_agent = embedder_support::GetUserAgent();
-  auto user_agent_mode = SessionSettings::Get()->GetUserAgentMode();
+  auto user_agent_mode = wolvic::SessionSettings::Get()->GetUserAgentMode();
   switch (user_agent_mode) {
-    case UserAgentMode::kMobile:
+    case wolvic::UserAgentMode::kMobile:
       AddPlatformToUserAgent("Mobile", &user_agent);
       break;
-    case UserAgentMode::kMobileVR:
+    case wolvic::UserAgentMode::kMobileVR:
       AddPlatformToUserAgent("Mobile VR", &user_agent);
       break;
-    case UserAgentMode::kDesktop:
+    case wolvic::UserAgentMode::kDesktop:
       // do nothing
       break;
   }
@@ -99,13 +99,13 @@ std::string WolvicContentBrowserClient::GetUserAgent() {
 
 blink::UserAgentMetadata WolvicContentBrowserClient::GetUserAgentMetadata() {
   auto metadata = embedder_support::GetUserAgentMetadata();
-  auto user_agent_mode = SessionSettings::Get()->GetUserAgentMode();
+  auto user_agent_mode = wolvic::SessionSettings::Get()->GetUserAgentMode();
   switch (user_agent_mode) {
-    case UserAgentMode::kMobile:
-    case UserAgentMode::kMobileVR:
+    case wolvic::UserAgentMode::kMobile:
+    case wolvic::UserAgentMode::kMobileVR:
       metadata.mobile = true;
       break;
-    case UserAgentMode::kDesktop:
+    case wolvic::UserAgentMode::kDesktop:
       metadata.mobile = false;
       break;
   }

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -77,20 +77,23 @@ XrIntegrationClient* WolvicContentBrowserClient::GetXrIntegrationClient() {
 #endif
 
 std::string WolvicContentBrowserClient::GetUserAgent() {
-  auto user_agent_override = wolvic::SessionSettings::Get()->GetUserAgentOverride();
+  typedef wolvic::SessionSettings::UserAgentMode UserAgentMode;
+
+  auto user_agent_override =
+      wolvic::SessionSettings::Get()->GetUserAgentOverride();
   if (user_agent_override)
     return *user_agent_override;
 
   std::string user_agent = embedder_support::GetUserAgent();
   auto user_agent_mode = wolvic::SessionSettings::Get()->GetUserAgentMode();
   switch (user_agent_mode) {
-    case wolvic::UserAgentMode::kMobile:
+    case UserAgentMode::kMobile:
       AddPlatformToUserAgent("Mobile", &user_agent);
       break;
-    case wolvic::UserAgentMode::kMobileVR:
+    case UserAgentMode::kMobileVR:
       AddPlatformToUserAgent("Mobile VR", &user_agent);
       break;
-    case wolvic::UserAgentMode::kDesktop:
+    case UserAgentMode::kDesktop:
       // do nothing
       break;
   }
@@ -98,14 +101,16 @@ std::string WolvicContentBrowserClient::GetUserAgent() {
 }
 
 blink::UserAgentMetadata WolvicContentBrowserClient::GetUserAgentMetadata() {
+  typedef wolvic::SessionSettings::UserAgentMode UserAgentMode;
+
   auto metadata = embedder_support::GetUserAgentMetadata();
   auto user_agent_mode = wolvic::SessionSettings::Get()->GetUserAgentMode();
   switch (user_agent_mode) {
-    case wolvic::UserAgentMode::kMobile:
-    case wolvic::UserAgentMode::kMobileVR:
+    case UserAgentMode::kMobile:
+    case UserAgentMode::kMobileVR:
       metadata.mobile = true;
       break;
-    case wolvic::UserAgentMode::kDesktop:
+    case UserAgentMode::kDesktop:
       metadata.mobile = false;
       break;
   }

--- a/wolvic/wolvic_content_browser_client.h
+++ b/wolvic/wolvic_content_browser_client.h
@@ -21,12 +21,6 @@ class WolvicContentBrowserClient : public ContentBrowserClient {
   WolvicContentBrowserClient& operator=(const WolvicContentBrowserClient&) =
       delete;
 
-  std::string GetUserAgent() override;
-  std::string GetUserAgentBasedOnPolicy(
-      content::BrowserContext* context) override;
-  std::string GetFullUserAgent() override;
-  std::string GetReducedUserAgent() override;
-
   ~WolvicContentBrowserClient() override;
 
   // Returns the single instance.
@@ -36,6 +30,8 @@ class WolvicContentBrowserClient : public ContentBrowserClient {
   content::BrowserContext* GetBrowserContext();
 
   // ContentBrowserClient overrides.
+  std::string GetUserAgent() override;
+  blink::UserAgentMetadata GetUserAgentMetadata() override;
   std::unique_ptr<BrowserMainParts> CreateBrowserMainParts(
       bool is_integration_test) override;
   std::unique_ptr<content::DevToolsManagerDelegate>

--- a/wolvic/wolvic_content_main_delegate.cc
+++ b/wolvic/wolvic_content_main_delegate.cc
@@ -153,7 +153,8 @@ base::flat_set<url::Origin> GetIsolatedContextOriginSetFromFlag() {
   return {};
 }
 
-WolvicContentMainDelegate::WolvicContentMainDelegate() {}
+WolvicContentMainDelegate::WolvicContentMainDelegate()
+    : session_settings_(std::make_unique<SessionSettings>()) {}
 
 WolvicContentMainDelegate::~WolvicContentMainDelegate() {}
 
@@ -387,6 +388,5 @@ void WolvicContentMainDelegate::SetUpFieldTrials() {
       &platform_field_trials, &safe_seed_manager,
       /*low_entropy_source_value=*/false);
 }
-
 
 }  // namespace content

--- a/wolvic/wolvic_content_main_delegate.cc
+++ b/wolvic/wolvic_content_main_delegate.cc
@@ -154,7 +154,7 @@ base::flat_set<url::Origin> GetIsolatedContextOriginSetFromFlag() {
 }
 
 WolvicContentMainDelegate::WolvicContentMainDelegate()
-    : session_settings_(std::make_unique<SessionSettings>()) {}
+    : session_settings_(std::make_unique<wolvic::SessionSettings>()) {}
 
 WolvicContentMainDelegate::~WolvicContentMainDelegate() {}
 

--- a/wolvic/wolvic_content_main_delegate.h
+++ b/wolvic/wolvic_content_main_delegate.h
@@ -14,6 +14,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/shell/browser/shell_paths.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
+#include "wolvic/browser/session_settings.h"
 
 class PrefService;
 
@@ -63,6 +64,7 @@ class WolvicContentMainDelegate : public ContentMainDelegate {
   std::unique_ptr<PrefService> CreateLocalState();
   void SetUpFieldTrials();
 
+  std::unique_ptr<SessionSettings> session_settings_;
   std::unique_ptr<PrefService> local_state_;
   std::unique_ptr<WolvicContentBrowserClient> browser_client_;
   std::unique_ptr<ContentGpuClient> gpu_client_;

--- a/wolvic/wolvic_content_main_delegate.h
+++ b/wolvic/wolvic_content_main_delegate.h
@@ -64,7 +64,7 @@ class WolvicContentMainDelegate : public ContentMainDelegate {
   std::unique_ptr<PrefService> CreateLocalState();
   void SetUpFieldTrials();
 
-  std::unique_ptr<SessionSettings> session_settings_;
+  std::unique_ptr<wolvic::SessionSettings> session_settings_;
   std::unique_ptr<PrefService> local_state_;
   std::unique_ptr<WolvicContentBrowserClient> browser_client_;
   std::unique_ptr<ContentGpuClient> gpu_client_;


### PR DESCRIPTION
Add a mechanism of sending Wolvic settings to the Chromium backend and also implements support for the User Agent settings. Logic for the User Agent support is using the same approach as the gecko backend (SessionImpl.java).

Additionally, remove GetUserAgentBasedOnPolicy() method since we're not planning to support any enterprise policies and our implementation of GetUserAgent() will be used by default.