### PR TITLE
Revert "Add a method to retrieve the default user agent"

### DIFF
--- a/wolvic/browser/session_settings.cc
+++ b/wolvic/browser/session_settings.cc
@@ -5,7 +5,6 @@
 #include "wolvic/browser/session_settings.h"
 
 #include "base/check.h"
-#include "components/embedder_support/user_agent_utils.h"
 
 namespace wolvic {
 
@@ -44,10 +43,6 @@ void SessionSettings::SetUserAgentOverride(
 
 absl::optional<std::string> SessionSettings::GetUserAgentOverride() const {
   return user_agent_override_;
-}
-
-std::string SessionSettings::GetDefaultUserAgent() const {
-  return embedder_support::GetUserAgent();
 }
 
 }  // namespace wolvic

--- a/wolvic/browser/session_settings.h
+++ b/wolvic/browser/session_settings.h
@@ -33,7 +33,6 @@ class SessionSettings {
   UserAgentMode GetUserAgentMode() const;
   void SetUserAgentOverride(const absl::optional<std::string>& value);
   absl::optional<std::string> GetUserAgentOverride() const;
-  std::string GetDefaultUserAgent() const;
 
  private:
   UserAgentMode user_agent_mode_ = UserAgentMode::kMobile;

--- a/wolvic/browser/session_settings_jni.cc
+++ b/wolvic/browser/session_settings_jni.cc
@@ -43,10 +43,4 @@ ScopedJavaLocalRef<jstring> JNI_SessionSettings_GetUserAgentOverride(
   return base::android::ConvertUTF8ToJavaString(env, *userAgentOverride);
 }
 
-ScopedJavaLocalRef<jstring> JNI_SessionSettings_GetDefaultUserAgent(
-    JNIEnv* env) {
-  return base::android::ConvertUTF8ToJavaString(
-      env, SessionSettings::Get()->GetDefaultUserAgent());
-}
-
 }  // namespace wolvic

--- a/wolvic/java/org/chromium/wolvic/SessionSettings.java
+++ b/wolvic/java/org/chromium/wolvic/SessionSettings.java
@@ -52,10 +52,6 @@ public class SessionSettings {
         return SessionSettingsJni.get().getUserAgentOverride();
     }
 
-    public String getDefaultUserAgent() {
-        return SessionSettingsJni.get().getDefaultUserAgent();
-    }
-
     @NativeMethods
     public interface Natives {
         void setUserAgentMode(int value);
@@ -63,6 +59,5 @@ public class SessionSettings {
         void setUserAgentOverride(@Nullable String value);
         @Nullable
         String getUserAgentOverride();
-        String getDefaultUserAgent();
     }
 }

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -78,14 +78,14 @@ XrIntegrationClient* WolvicContentBrowserClient::GetXrIntegrationClient() {
 
 std::string WolvicContentBrowserClient::GetUserAgent() {
   typedef wolvic::SessionSettings::UserAgentMode UserAgentMode;
-  auto* session_settings = wolvic::SessionSettings::Get();
 
-  auto user_agent_override = session_settings->GetUserAgentOverride();
+  auto user_agent_override =
+      wolvic::SessionSettings::Get()->GetUserAgentOverride();
   if (user_agent_override)
     return *user_agent_override;
 
-  std::string user_agent = session_settings->GetDefaultUserAgent();
-  auto user_agent_mode = session_settings->GetUserAgentMode();
+  std::string user_agent = embedder_support::GetUserAgent();
+  auto user_agent_mode = wolvic::SessionSettings::Get()->GetUserAgentMode();
   switch (user_agent_mode) {
     case UserAgentMode::kMobile:
       AddPlatformToUserAgent("Mobile", user_agent);


### PR DESCRIPTION
Reverts Igalia/wolvic-chromium#20

This is not really what we need. We need to get access to the UA that is used by chromium which is not neccessarily the one from embedder_support as we make some changes to it in the content client