### PR TITLE
Add SessionSettings::GetDefaultUserAgent()

### DIFF
--- a/wolvic/browser/session_settings.cc
+++ b/wolvic/browser/session_settings.cc
@@ -5,6 +5,8 @@
 #include "wolvic/browser/session_settings.h"
 
 #include "base/check.h"
+#include "components/embedder_support/user_agent_utils.h"
+#include "content/public/common/user_agent.h"
 
 namespace wolvic {
 
@@ -43,6 +45,30 @@ void SessionSettings::SetUserAgentOverride(
 
 absl::optional<std::string> SessionSettings::GetUserAgentOverride() const {
   return user_agent_override_;
+}
+
+std::string SessionSettings::GetDefaultUserAgent(UserAgentMode mode) const {
+  static std::string kWolvicUserAgent;
+  static std::string kWolvicUserAgentVR;
+  static std::string kWolvicUserAgentDesktop;
+
+  static std::once_flag once_flag;
+  std::call_once(once_flag, [] {
+    kWolvicUserAgent = embedder_support::GetUserAgent() + " Mobile";
+    kWolvicUserAgentVR = embedder_support::GetUserAgent() + " Mobile VR";
+
+    const char kLinuxInfoStr[] = "X11; Linux x86_64";
+    kWolvicUserAgentDesktop = content::BuildUserAgentFromOSAndProduct(kLinuxInfoStr, embedder_support::GetProductAndVersion());
+  });
+
+  switch (mode) {
+    case UserAgentMode::kMobile:
+      return kWolvicUserAgent;
+    case UserAgentMode::kMobileVR:
+      return kWolvicUserAgentVR;
+    case UserAgentMode::kDesktop:
+      return kWolvicUserAgentDesktop;
+  }
 }
 
 }  // namespace wolvic

--- a/wolvic/browser/session_settings.h
+++ b/wolvic/browser/session_settings.h
@@ -34,6 +34,8 @@ class SessionSettings {
   void SetUserAgentOverride(const absl::optional<std::string>& value);
   absl::optional<std::string> GetUserAgentOverride() const;
 
+  std::string GetDefaultUserAgent(UserAgentMode mode) const;
+
  private:
   UserAgentMode user_agent_mode_ = UserAgentMode::kMobile;
   absl::optional<std::string> user_agent_override_;

--- a/wolvic/browser/session_settings_jni.cc
+++ b/wolvic/browser/session_settings_jni.cc
@@ -43,4 +43,9 @@ ScopedJavaLocalRef<jstring> JNI_SessionSettings_GetUserAgentOverride(
   return base::android::ConvertUTF8ToJavaString(env, *userAgentOverride);
 }
 
+ScopedJavaLocalRef<jstring> JNI_SessionSettings_GetDefaultUserAgent(JNIEnv* env, jint value) {
+  return base::android::ConvertUTF8ToJavaString(
+      env, SessionSettings::Get()->GetDefaultUserAgent(static_cast<SessionSettings::UserAgentMode>(value)));
+}
+
 }  // namespace wolvic

--- a/wolvic/java/org/chromium/wolvic/SessionSettings.java
+++ b/wolvic/java/org/chromium/wolvic/SessionSettings.java
@@ -52,6 +52,10 @@ public class SessionSettings {
         return SessionSettingsJni.get().getUserAgentOverride();
     }
 
+    public String getDefaultUserAgent(UserAgentMode mode) {
+        return SessionSettingsJni.get().getDefaultUserAgent(mode.getValue());
+    }
+
     @NativeMethods
     public interface Natives {
         void setUserAgentMode(int value);
@@ -59,5 +63,6 @@ public class SessionSettings {
         void setUserAgentOverride(@Nullable String value);
         @Nullable
         String getUserAgentOverride();
+        String getDefaultUserAgent(int value);
     }
 }

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -19,18 +19,6 @@ namespace {
 
 WolvicContentBrowserClient* g_instance = nullptr;
 
-// Adds the given platform to the user agent string. For example, if
-// we add "Mobile VR" platform to the following user agent
-// "Mozilla/5.0 (Linux; Android 8.0.0; Quest 2)", the result will be:
-// "Mozilla/5.0 (Linux; Android 8.0.0; Quest 2; Mobile VR)".
-void AddPlatformToUserAgent(const std::string& platform,
-                            std::string& user_agent) {
-  size_t pos = user_agent.find(')');
-  if (pos != std::string::npos) {
-    user_agent.insert(pos, "; " + platform);
-  }
-}
-
 }  // namespace
 
 WolvicContentBrowserClient::WolvicContentBrowserClient()
@@ -77,27 +65,11 @@ XrIntegrationClient* WolvicContentBrowserClient::GetXrIntegrationClient() {
 #endif
 
 std::string WolvicContentBrowserClient::GetUserAgent() {
-  typedef wolvic::SessionSettings::UserAgentMode UserAgentMode;
-
-  auto user_agent_override =
-      wolvic::SessionSettings::Get()->GetUserAgentOverride();
-  if (user_agent_override)
+  auto* settings = wolvic::SessionSettings::Get();
+  if (auto user_agent_override = settings->GetUserAgentOverride())
     return *user_agent_override;
 
-  std::string user_agent = embedder_support::GetUserAgent();
-  auto user_agent_mode = wolvic::SessionSettings::Get()->GetUserAgentMode();
-  switch (user_agent_mode) {
-    case UserAgentMode::kMobile:
-      AddPlatformToUserAgent("Mobile", user_agent);
-      break;
-    case UserAgentMode::kMobileVR:
-      AddPlatformToUserAgent("Mobile VR", user_agent);
-      break;
-    case UserAgentMode::kDesktop:
-      // do nothing
-      break;
-  }
-  return user_agent;
+  return settings->GetDefaultUserAgent(settings->GetUserAgentMode());
 }
 
 blink::UserAgentMetadata WolvicContentBrowserClient::GetUserAgentMetadata() {


### PR DESCRIPTION
Added a new method that retrieves the UA to be used by Chromium for a given
mode (mobile, desktop or VR). Part of the existing code has to be moved from
the content browser client to session settings in order to allow both Wolvic and
the WolvicContentBrowserClient to access it.