### PR TITLE
Initialize the UserLevelMemoryPressureSignalGenerator

### DIFF
--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -6,6 +6,8 @@
 
 #include "components/embedder_support/user_agent_utils.h"
 #include "components/prefs/pref_service.h"
+#include "content/public/browser/user_level_memory_pressure_signal_features.h"
+#include "content/public/common/content_switches.h"
 #include "content/shell/browser/shell.h"
 #include "content/shell/browser/shell_devtools_manager_delegate.h"
 #include "wolvic/browser/session_settings.h"
@@ -87,6 +89,40 @@ blink::UserAgentMetadata WolvicContentBrowserClient::GetUserAgentMetadata() {
       break;
   }
   return metadata;
+}
+
+void WolvicContentBrowserClient::AppendExtraCommandLineSwitches(
+    base::CommandLine* command_line,
+    int child_process_id) {
+  // The following code adds the command line flag to correctly initialize the
+  // UserLevelMemoryPressureSignalGenerator feature. It's copied
+  // from chrome/browser/chrome_content_browser_client.cc.
+#if BUILDFLAG(IS_ANDROID)
+  // The browser process only decides to enable or disable
+  // UserLevelMemoryPressureSignalGenerator feature. Renderer processes
+  // follow the decision. If the browser process enables the feature, renderer
+  // processes will provide private memory footprint for the browser process
+  // and will generate memory pressure signals when the browser process
+  // requests. So the decision will be provided for renderer processes
+  // via commandline flag.
+  std::ostringstream user_level_memory_pressure_params;
+  if (features::IsUserLevelMemoryPressureSignalEnabledOn4GbDevices()) {
+    user_level_memory_pressure_params
+        << features::InertIntervalFor4GbDevices().InSeconds() << "s,"
+        << features::MinUserMemoryPressureIntervalOn4GbDevices().InSeconds()
+        << "s";
+  } else if (features::IsUserLevelMemoryPressureSignalEnabledOn6GbDevices()) {
+    user_level_memory_pressure_params
+        << features::InertIntervalFor6GbDevices().InSeconds() << "s,"
+        << features::MinUserMemoryPressureIntervalOn6GbDevices().InSeconds()
+        << "s";
+  }
+  if (user_level_memory_pressure_params.tellp() > 0) {
+    command_line->AppendSwitchASCII(
+        switches::kUserLevelMemoryPressureSignalParams,
+        user_level_memory_pressure_params.str());
+  }
+#endif  // BUILDFLAG(IS_ANDROID)
 }
 
 }  // namespace content

--- a/wolvic/wolvic_content_browser_client.h
+++ b/wolvic/wolvic_content_browser_client.h
@@ -39,6 +39,8 @@ class WolvicContentBrowserClient : public ContentBrowserClient {
 #if BUILDFLAG(ENABLE_VR)
   XrIntegrationClient* GetXrIntegrationClient() override;
 #endif
+  void AppendExtraCommandLineSwitches(base::CommandLine* command_line,
+                                      int child_process_id) override;
 
  private:
   WolvicMainParts* browser_main_parts_;


### PR DESCRIPTION
In this change we copy the chrome code for user level memory pressure signals initialization (adding the corresponding command line flag). Without this, WebXR experiences crash on Oculus Quest 2 devices.