### PR TITLE
Forward downloads to Wolvic

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -29,6 +29,8 @@ shared_library("libcontent_native") {
     "../content/shell/browser/shell_platform_delegate_android.cc",
     "../content/shell/common/shell_switches.cc",
     "../content/shell/common/shell_switches.h",
+    "browser/downloads/wolvic_download_manager_delegate.cc",
+    "browser/downloads/wolvic_download_manager_delegate.h",
     "browser/session_settings.cc",
     "browser/session_settings.h",
     "browser/session_settings_jni.cc",
@@ -193,6 +195,7 @@ jinja_template("content_manifest") {
 
 generate_jni("jni_headers") {
   sources = [
+    "java/org/chromium/wolvic/DownloadManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",
     "java/org/chromium/wolvic/VRManager.java",
@@ -202,6 +205,7 @@ generate_jni("jni_headers") {
 
 android_library("wolvic_java") {
   sources = [
+    "java/org/chromium/wolvic/DownloadManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",
     "java/org/chromium/wolvic/TabCompositorView.java",
@@ -262,6 +266,7 @@ dist_aar("content_aar") {
     "org/chromium/blink/mojom/*.class",
     "org/chromium/build/*.class",
     "org/chromium/components/browser_ui/media/*.class",
+    "org/chromium/components/download/*.class",
     "org/chromium/components/embedder_support/delegate/*.class",
     "org/chromium/components/embedder_support/view/*.class",
     "org/chromium/components/metrics/*.class",

--- a/wolvic/browser/downloads/wolvic_download_manager_delegate.cc
+++ b/wolvic/browser/downloads/wolvic_download_manager_delegate.cc
@@ -1,0 +1,41 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/browser/downloads/wolvic_download_manager_delegate.h"
+
+#include "base/android/jni_string.h"
+#include "base/logging.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+#include "wolvic/jni_headers/DownloadManagerBridge_jni.h"
+
+namespace wolvic {
+
+using base::android::ScopedJavaLocalRef;
+
+bool WolvicDownloadManagerDelegate::InterceptDownloadIfApplicable(
+    const GURL& url,
+    const std::string& user_agent,
+    const std::string& content_disposition,
+    const std::string& mime_type,
+    const std::string& request_origin,
+    int64_t content_length,
+    bool is_transient,
+    content::WebContents* web_contents) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  JNIEnv* env = base::android::AttachCurrentThread();
+
+  if (!web_contents) {
+    return true;
+  }
+
+  DVLOG(1) << "Forwarding the download to Wolvic: " << url.spec();
+
+  ScopedJavaLocalRef<jstring> jstring_url =
+      base::android::ConvertUTF8ToJavaString(env, url.spec());
+  Java_DownloadManagerBridge_newDownload(env, jstring_url);
+  return true;
+}
+
+}  // namespace wolvic

--- a/wolvic/browser/downloads/wolvic_download_manager_delegate.h
+++ b/wolvic/browser/downloads/wolvic_download_manager_delegate.h
@@ -1,0 +1,36 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WOLVIC_WOLVIC_BROWSER_DOWNLOADS_WOLVIC_DOWNLOAD_MANAGER_DELEGATE_H_
+#define WOLVIC_WOLVIC_BROWSER_DOWNLOADS_WOLVIC_DOWNLOAD_MANAGER_DELEGATE_H_
+
+#include "content/public/browser/download_manager_delegate.h"
+
+namespace wolvic {
+
+class WolvicDownloadManagerDelegate : public content::DownloadManagerDelegate {
+ public:
+  WolvicDownloadManagerDelegate() = default;
+
+  WolvicDownloadManagerDelegate(const WolvicDownloadManagerDelegate&) = delete;
+  WolvicDownloadManagerDelegate& operator=(
+      const WolvicDownloadManagerDelegate&) = delete;
+
+  ~WolvicDownloadManagerDelegate() override = default;
+
+  // content::DownloadManagerDelegate implementation.
+  bool InterceptDownloadIfApplicable(
+      const GURL& url,
+      const std::string& user_agent,
+      const std::string& content_disposition,
+      const std::string& mime_type,
+      const std::string& request_origin,
+      int64_t content_length,
+      bool is_transient,
+      content::WebContents* web_contents) override;
+};
+
+}  // namespace wolvic
+
+#endif  // WOLVIC_WOLVIC_BROWSER_DOWNLOADS_WOLVIC_DOWNLOAD_MANAGER_DELEGATE_H_

--- a/wolvic/java/org/chromium/wolvic/DownloadManagerBridge.java
+++ b/wolvic/java/org/chromium/wolvic/DownloadManagerBridge.java
@@ -1,0 +1,43 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import androidx.annotation.NonNull;
+
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+
+@JNINamespace("wolvic")
+public class DownloadManagerBridge {
+    public interface Delegate {
+        void newDownload(String url);
+    }
+
+    private static DownloadManagerBridge sInstance;
+    private Delegate mDelegate;
+
+    public static DownloadManagerBridge get() {
+        if (sInstance == null) {
+            sInstance = new DownloadManagerBridge();
+        }
+        return sInstance;
+    }
+
+    // Called from the Java side to set the delegate that will accept the calls
+    // from the native side.
+    public void setDelegate(@NonNull Delegate delegate) {
+        mDelegate = delegate;
+    }
+
+    // Called from the native side to notify Wolvic about the new download that
+    // must be handled by Wolvic.
+    @CalledByNative
+    public static void newDownload(String url) {
+        DownloadManagerBridge bridge = get();
+        if (bridge.mDelegate != null) {
+            bridge.mDelegate.newDownload(url);
+        }
+    }
+}

--- a/wolvic/wolvic_browser_context.cc
+++ b/wolvic/wolvic_browser_context.cc
@@ -38,6 +38,7 @@
 #include "content/test/mock_background_sync_controller.h"
 #include "content/test/mock_reduce_accept_language_controller_delegate.h"
 #include "third_party/blink/public/common/origin_trials/trial_token_validator.h"
+#include "wolvic/browser/downloads/wolvic_download_manager_delegate.h"
 
 namespace content {
 
@@ -99,7 +100,11 @@ bool WolvicBrowserContext::IsOffTheRecord() {
 }
 
 DownloadManagerDelegate* WolvicBrowserContext::GetDownloadManagerDelegate() {
-  return nullptr;
+  if (!download_manager_delegate_) {
+    download_manager_delegate_ =
+        std::make_unique<wolvic::WolvicDownloadManagerDelegate>();
+  }
+  return download_manager_delegate_.get();
 }
 
 ResourceContext* WolvicBrowserContext::GetResourceContext() {

--- a/wolvic/wolvic_browser_context.h
+++ b/wolvic/wolvic_browser_context.h
@@ -12,6 +12,7 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/resource_context.h"
+#include "wolvic/browser/downloads/wolvic_download_manager_delegate.h"
 
 class SimpleFactoryKey;
 
@@ -61,6 +62,8 @@ class WolvicBrowserContext : public BrowserContext {
   std::unique_ptr<ContentIndexProvider> content_index_provider_;
   std::unique_ptr<ReduceAcceptLanguageControllerDelegate>
       reduce_accept_lang_controller_delegate_;
+  std::unique_ptr<wolvic::WolvicDownloadManagerDelegate>
+      download_manager_delegate_;
 
  private:
   // Performs initialization of the WolvicBrowserContext while IO is still


### PR DESCRIPTION
Intercept any files that download manager is trying to download and forward them to be handled on the Wolvic side instead.