### PR TITLE
Fix texture size and remove time out task

### DIFF
--- a/wolvic/browser/vr/wvr_api.cc
+++ b/wolvic/browser/vr/wvr_api.cc
@@ -119,4 +119,11 @@ bool WvrApi::SyncState(uint64_t frame_index,
   return true;
 }
 
+void WvrApi::PullSystemState() {
+  PullState([&]() {
+    return !system_state_.displayState.suppressFrames &&
+           system_state_.displayState.isConnected;
+  });
+}
+
 }  // namespace wolvic

--- a/wolvic/browser/vr/wvr_api.h
+++ b/wolvic/browser/vr/wvr_api.h
@@ -29,6 +29,7 @@ class WvrApi {
                  int32_t texture_handle,
                  int32_t width,
                  int32_t height);
+  void PullSystemState();
 
   mozilla::gfx::VRSystemState get_system_state() { return system_state_; }
 

--- a/wolvic/browser/vr/wvr_device.cc
+++ b/wolvic/browser/vr/wvr_device.cc
@@ -103,10 +103,9 @@ bool WvrDevice::IsOnMainThread() {
 
 void WvrDevice::OnWvrThreadReady(
     device::mojom::XRRuntimeSessionOptionsPtr options) {
-  display::Display display = display::Screen::GetScreen()->GetPrimaryDisplay();
   PostTaskToWvrThread(base::BindOnce(
       &WvrGraphicsDelegate::InitializeGl, wvr_thread_->GetWvrGraphics()->GetWeakPtr(),
-      display.GetSizeInPixel(),
+      wvr_thread_->GetWvrManager()->GetSuggestedFrameSize(),
       CreateMainThreadCallback(
           base::BindOnce(&WvrDevice::OnWvrGlInitializationComplete,
                          GetWeakPtr(), std::move(options)))));

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -220,6 +220,18 @@ bool WvrManager::IsOnWvrThread() const {
   return task_runner_->BelongsToCurrentThread();
 }
 
+gfx::Size WvrManager::GetSuggestedFrameSize() const {
+  // Make sure we're fetching an up to date state.
+  wvr_api_->PullSystemState();
+
+  const mozilla::gfx::VRDisplayState& ds =
+      wvr_api_->get_system_state().displayState;
+
+  // We compute the suggested frame size based on eye resolution.
+  gfx::Size frame_size(ds.eyeResolution.width * 2, ds.eyeResolution.height);
+  return frame_size;
+}
+
 void WvrManager::CreateOrResizeWebXrSurface(const gfx::Size& size) {
   DCHECK(IsOnWvrThread());
   if (!graphics_->CreateOrResizeWebXrSurface(

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -16,8 +16,6 @@ namespace wolvic {
 
 namespace {
 
-const int64_t kFrameTimeOutMilliseconds = 1000;
-
 void WvrMatToTransform(const float in[16], gfx::Transform* out) {
   *out = gfx::Transform::RowMajor(in[0], in[1], in[2], in[3], in[4], in[5],
                                   in[6], in[7], in[8], in[9], in[10], in[11],
@@ -359,9 +357,6 @@ void WvrManager::OnWebXrFrameAvailable() {
   DVLOG(2) << __func__ << "frame: " << frame_index;
   pending_frames_.pop();
 
-  if (!webxr_frame_timeout_closure_.IsCancelled())
-    webxr_frame_timeout_closure_.Cancel();
-
   // LIFECYCLE: we should be in processing state.
   DCHECK(webxr_.HaveProcessingFrame());
   device::WebXrFrame* processing_frame = webxr_.GetProcessingFrame();
@@ -374,15 +369,7 @@ void WvrManager::OnWebXrFrameAvailable() {
   DrawFrameSubmitNow(processing_frame);
 }
 
-void WvrManager::OnWebXrTimedOut() {
-  DCHECK(IsOnWvrThread());
-  OnWebXrFrameAvailable();
-}
-
 void WvrManager::ClosePresentationBindings() {
-  if (!webxr_frame_timeout_closure_.IsCancelled())
-    webxr_frame_timeout_closure_.Cancel();
-
   if (!get_frame_data_callback_.is_null())
     std::move(get_frame_data_callback_).Run(nullptr);
 
@@ -785,13 +772,6 @@ void WvrManager::ProcessWebVrFrameFromMailbox(
   // Notify the client that we're done with the mailbox so that the underlying
   // image is eligible for destruction.
   submit_client_->OnSubmitFrameTransferred(true);
-
-  webxr_frame_timeout_closure_.Reset(
-      base::BindOnce(&WvrManager::OnWebXrTimedOut, GetWeakPtr()));
-
-  task_runner_->PostDelayedTask(FROM_HERE,
-                                webxr_frame_timeout_closure_.callback(),
-                                base::Milliseconds(kFrameTimeOutMilliseconds));
 }
 
 void WvrManager::SubmitFrameDrawnIntoTexture(int16_t frame_index,

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -558,9 +558,6 @@ WvrManager::GetInputSourceState() {
 }
 
 void WvrManager::DrawFrameSubmitNow(device::WebXrFrame* processing_frame) {
-  if (!SubmitFrameInternal(processing_frame->index))
-    return;
-
   // Report rendering completion to the Renderer so that it's permitted to
   // submit a fresh frame. We could do this earlier, as soon as the frame
   // got pulled off the transfer surface, but that results in overstuffed
@@ -624,10 +621,16 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
   }
 
   device::mojom::XRFrameDataPtr frame_data = device::mojom::XRFrameData::New();
+
+  frame_data->frame_id = webxr_.StartFrameAnimating();
+
+  // Process all events.
+  if (!SubmitFrameInternal(frame_data->frame_id))
+   return;
+
   mozilla::gfx::VRSystemState system_state = wvr_api_->get_system_state();
   const mozilla::gfx::VRPose* pose = &system_state.sensorState.pose;
 
-  frame_data->frame_id = webxr_.StartFrameAnimating();
   frame_data->views =
       CreateViews(wvr_api_->get_system_state().displayState,
                   pose,

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -97,7 +97,6 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   void CreateSurfaceBridge(gl::SurfaceTexture* surface_texture);
 
   void OnWebXrFrameAvailable();
-  void OnWebXrTimedOut();
 
   std::vector<device::mojom::XRInputSourceStatePtr> GetInputSourceState();
 
@@ -142,8 +141,6 @@ class WvrManager : public device::mojom::XRPresentationProvider,
 
   device::WebXrPresentationState webxr_;
   std::unique_ptr<device::MailboxToSurfaceBridge> mailbox_bridge_;
-
-  base::CancelableOnceClosure webxr_frame_timeout_closure_;
 
   base::OnceClosure exit_vr_callback_;
 

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -78,6 +78,8 @@ class WvrManager : public device::mojom::XRPresentationProvider,
       base::OnceClosure exit_callback);
   void ExitWebXRPresentation(base::OnceClosure callback);
 
+  gfx::Size GetSuggestedFrameSize() const;
+
  private:
   bool IsOnWvrThread() const;
 


### PR DESCRIPTION
This PR contains two important fixes: it sets a correct WebXR texture size based on the underlying runtime (either OpenXR or VrApi) and also removes a visual artifact caused by the time out task workaround for scheduling frames.

I kindly suggest to the reviewer check each commit individually instead the whole PR. Thank you!