### PR TITLE
wolvic: Lazy evaluate texture size for views

### DIFF
--- a/wolvic/browser/vr/wvr_device.cc
+++ b/wolvic/browser/vr/wvr_device.cc
@@ -105,7 +105,6 @@ void WvrDevice::OnWvrThreadReady(
     device::mojom::XRRuntimeSessionOptionsPtr options) {
   PostTaskToWvrThread(base::BindOnce(
       &WvrGraphicsDelegate::InitializeGl, wvr_thread_->GetWvrGraphics()->GetWeakPtr(),
-      wvr_thread_->GetWvrManager()->GetSuggestedFrameSize(),
       CreateMainThreadCallback(
           base::BindOnce(&WvrDevice::OnWvrGlInitializationComplete,
                          GetWeakPtr(), std::move(options)))));

--- a/wolvic/browser/vr/wvr_graphics_delegate.cc
+++ b/wolvic/browser/vr/wvr_graphics_delegate.cc
@@ -41,10 +41,7 @@ base::WeakPtr<WvrGraphicsDelegate> WvrGraphicsDelegate::GetWeakPtr() {
   return weak_ptr_factory_.GetWeakPtr();
 }
 
-void WvrGraphicsDelegate::InitializeGl(const gfx::Size& frame_size,
-                                       base::OnceClosure callback) {
-  screen_size_ = frame_size;
-
+void WvrGraphicsDelegate::InitializeGl(base::OnceClosure callback) {
   gl::init::DisableANGLE();
 
   gl::GLDisplay* display = nullptr;

--- a/wolvic/browser/vr/wvr_graphics_delegate.h
+++ b/wolvic/browser/vr/wvr_graphics_delegate.h
@@ -35,8 +35,7 @@ class WvrGraphicsDelegate {
     webxr_ = webxr;
   }
 
-  void InitializeGl(const gfx::Size& frame_size,
-                    base::OnceClosure callback);
+  void InitializeGl(base::OnceClosure callback);
 
   base::WeakPtr<WvrGraphicsDelegate> GetWeakPtr();
 
@@ -47,7 +46,6 @@ class WvrGraphicsDelegate {
   gl::SurfaceTexture* webxr_surface_texture() {
     return webxr_surface_texture_.get();
   }
-  gfx::Size get_screen_size() const { return screen_size_; }
   gfx::Size webxr_surface_size() const { return webxr_surface_size_; }
   int32_t webxr_texture_handle() const { return texture_handle_id_; }
 
@@ -65,7 +63,6 @@ class WvrGraphicsDelegate {
   scoped_refptr<gl::GLSurface> surface_;
   scoped_refptr<gl::SurfaceTexture> webxr_surface_texture_;
 
-  gfx::Size screen_size_;
   gfx::Size webxr_surface_size_;
 
   base::WeakPtrFactory<WvrGraphicsDelegate> weak_ptr_factory_{this};

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -157,16 +157,29 @@ device::mojom::XRViewPtr CreateView(
   return view;
 }
 
+gfx::Size GetSuggestedFrameSize(WvrApi* wvr_api) {
+  // Make sure we're fetching an up to date state.
+  wvr_api->PullSystemState();
+
+  const mozilla::gfx::VRDisplayState& ds =
+      wvr_api->get_system_state().displayState;
+
+  // We compute the suggested frame size based on eye resolution.
+  gfx::Size frame_size(ds.eyeResolution.width * 2, ds.eyeResolution.height);
+  return frame_size;
+}
+
 std::vector<device::mojom::XRViewPtr> CreateViews(
-    const mozilla::gfx::VRDisplayState& display_state,
-    const mozilla::gfx::VRPose* pose,
-    gfx::Size maximum_size) {
+    WvrApi* wvr_api, const mozilla::gfx::VRPose* pose) {
+  const mozilla::gfx::VRDisplayState& display_state =
+    wvr_api->get_system_state().displayState;
+  gfx::Size suggested_size = GetSuggestedFrameSize(wvr_api);
+
   std::vector<device::mojom::XRViewPtr> views(2);
   views[0] = CreateView(mozilla::gfx::VRDisplayState::Eye::Eye_Left,
-                        display_state, maximum_size, pose);
+                        display_state, suggested_size, pose);
   views[1] = CreateView(mozilla::gfx::VRDisplayState::Eye::Eye_Right,
-                        display_state, maximum_size, pose);
-
+                        display_state, suggested_size, pose);
   return views;
 }
 
@@ -216,18 +229,6 @@ bool WvrManager::IsOnWvrThread() const {
   return task_runner_->BelongsToCurrentThread();
 }
 
-gfx::Size WvrManager::GetSuggestedFrameSize() const {
-  // Make sure we're fetching an up to date state.
-  wvr_api_->PullSystemState();
-
-  const mozilla::gfx::VRDisplayState& ds =
-      wvr_api_->get_system_state().displayState;
-
-  // We compute the suggested frame size based on eye resolution.
-  gfx::Size frame_size(ds.eyeResolution.width * 2, ds.eyeResolution.height);
-  return frame_size;
-}
-
 void WvrManager::CreateOrResizeWebXrSurface(const gfx::Size& size) {
   DCHECK(IsOnWvrThread());
   if (!graphics_->CreateOrResizeWebXrSurface(
@@ -268,8 +269,7 @@ void WvrManager::ConnectPresentingService(
   ClosePresentationBindings();
 
   std::vector<device::mojom::XRViewPtr> views =
-      CreateViews(wvr_api_->get_system_state().displayState, nullptr /*pose*/,
-                  graphics_->get_screen_size());
+      CreateViews(wvr_api_, nullptr /*pose*/);
   int width = 0;
   int height = 0;
   for (const auto& view : views) {
@@ -616,10 +616,7 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
   mozilla::gfx::VRSystemState system_state = wvr_api_->get_system_state();
   const mozilla::gfx::VRPose* pose = &system_state.sensorState.pose;
 
-  frame_data->views =
-      CreateViews(wvr_api_->get_system_state().displayState,
-                  pose,
-                  graphics_->webxr_surface_size());
+  frame_data->views = CreateViews(wvr_api_, pose);
 
   frame_data->mojo_space_reset = true;
 

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -78,8 +78,6 @@ class WvrManager : public device::mojom::XRPresentationProvider,
       base::OnceClosure exit_callback);
   void ExitWebXRPresentation(base::OnceClosure callback);
 
-  gfx::Size GetSuggestedFrameSize() const;
-
  private:
   bool IsOnWvrThread() const;
 


### PR DESCRIPTION
Move WvrManager::GetSuggestedFrameSize call to later at CreateViews, and get rid of screen_size attribute in the WvrGraphicsDelegate.

There are no functional changes in this commit.