### PR TITLE
gpu: Increase texture size limit

### DIFF
--- a/gpu/config/gpu_driver_bug_list.json
+++ b/gpu/config/gpu_driver_bug_list.json
@@ -1115,6 +1115,16 @@
       ]
     },
     {
+      "id": 147,
+      "description": "Limit max texure size to 4096 on all of Android",
+      "os": {
+        "type": "android"
+      },
+      "features": [
+        "webgl_or_caps_max_texture_size_limit_4096"
+      ]
+    },
+    {
       "id": 149,
       "description": "Direct composition flashes black initially on Win <10",
       "cr_bugs": [588588],

--- a/gpu/config/gpu_driver_bug_list.json
+++ b/gpu/config/gpu_driver_bug_list.json
@@ -1115,16 +1115,6 @@
       ]
     },
     {
-      "id": 147,
-      "description": "Limit max texure size to 4096 on all of Android",
-      "os": {
-        "type": "android"
-      },
-      "features": [
-        "webgl_or_caps_max_texture_size_limit_4096"
-      ]
-    },
-    {
       "id": 149,
       "description": "Direct composition flashes black initially on Win <10",
       "cr_bugs": [588588],

--- a/gpu/config/gpu_driver_bug_workarounds.cc
+++ b/gpu/config/gpu_driver_bug_workarounds.cc
@@ -26,8 +26,9 @@ void IntSetToWorkarounds(const std::vector<int32_t>& enabled_workarounds,
         NOTIMPLEMENTED();
     }
   }
+  // TODO(wolvic-chromium): VR experiences are over 4k.
   if (workarounds->webgl_or_caps_max_texture_size_limit_4096)
-    workarounds->webgl_or_caps_max_texture_size = 4096;
+    workarounds->webgl_or_caps_max_texture_size = 16384;
 
   if (workarounds->max_copy_texture_chromium_size_1048576)
     workarounds->max_copy_texture_chromium_size = 1048576;


### PR DESCRIPTION
WebXR textures for VR experiences are naturally over 4k and this limitation is a problem on those cases.

We may want to adjust this to address such scenario and eventually upload to upstream.