### PR TITLE
wolvic: Enable disk cache

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -70,6 +70,7 @@ shared_library("libcontent_native") {
     "//components/crash/content/browser",
     "//device/vr:vr_util",
     "//media",
+    "//services/network/public/mojom",
     "//skia",
   ]
 

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -4,12 +4,14 @@
 
 #include "wolvic/wolvic_content_browser_client.h"
 
+#include "base/path_service.h"
 #include "components/embedder_support/user_agent_utils.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/user_level_memory_pressure_signal_features.h"
 #include "content/public/common/content_switches.h"
 #include "content/shell/browser/shell.h"
 #include "content/shell/browser/shell_devtools_manager_delegate.h"
+#include "services/network/public/mojom/network_context.mojom.h"
 #include "wolvic/browser/session_settings.h"
 #include "wolvic/browser/youtube/youtube_url_loader_request_interceptor.h"
 #include "wolvic/wolvic_browser_context.h"
@@ -95,6 +97,19 @@ blink::UserAgentMetadata WolvicContentBrowserClient::GetUserAgentMetadata() {
       break;
   }
   return metadata;
+}
+
+void WolvicContentBrowserClient::ConfigureNetworkContextParams(
+    BrowserContext* context,
+    bool in_memory,
+    const base::FilePath& relative_partition_path,
+    network::mojom::NetworkContextParams* network_context_params,
+    cert_verifier::mojom::CertVerifierCreationParams*
+        cert_verifier_creation_params) {
+  base::FilePath user_data_path;
+  base::PathService::Get(SHELL_DIR_USER_DATA, &user_data_path);
+  network_context_params->http_cache_directory =
+      user_data_path.Append(FILE_PATH_LITERAL("Cache"));
 }
 
 void WolvicContentBrowserClient::AppendExtraCommandLineSwitches(

--- a/wolvic/wolvic_content_browser_client.h
+++ b/wolvic/wolvic_content_browser_client.h
@@ -33,6 +33,13 @@ class WolvicContentBrowserClient : public ContentBrowserClient {
   // ContentBrowserClient overrides.
   std::string GetUserAgent() override;
   blink::UserAgentMetadata GetUserAgentMetadata() override;
+  void ConfigureNetworkContextParams(
+      BrowserContext* context,
+      bool in_memory,
+      const base::FilePath& relative_partition_path,
+      network::mojom::NetworkContextParams* network_context_params,
+      cert_verifier::mojom::CertVerifierCreationParams*
+          cert_verifier_creation_params) override;
   std::unique_ptr<BrowserMainParts> CreateBrowserMainParts(
       bool is_integration_test) override;
   std::unique_ptr<content::DevToolsManagerDelegate>


### PR DESCRIPTION
This commit enables disk cache directory for the current user profile. To verify the correctness one can check that the index files are being created e.g.:

  $ adb shell run-as com.igalia.wolvic
  find -type f | grep Cache
  ./app_content_shell/content_shell/Cache/Cache_Data/*

This was tested with Oculus Quest 2 (Oculus API) and S21 (No API) devices.

Worth mentioning that Content Shell, in the upstream, could benefit from a very similar change in
content/shell/browser/shell_content_browser_client.cc.