### PR TITLE
Add support for WebXR Hand Input Module - Level 1

### DIFF
--- a/device/vr/public/cpp/features.cc
+++ b/device/vr/public/cpp/features.cc
@@ -11,7 +11,7 @@ namespace device::features {
 // Enables access to articulated hand tracking sensor input.
 BASE_FEATURE(kWebXrHandInput,
              "WebXRHandInput",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 // Enables access to experimental WebXR features.
 BASE_FEATURE(kWebXrIncubations,

--- a/device/vr/public/cpp/features.cc
+++ b/device/vr/public/cpp/features.cc
@@ -11,7 +11,7 @@ namespace device::features {
 // Enables access to articulated hand tracking sensor input.
 BASE_FEATURE(kWebXrHandInput,
              "WebXRHandInput",
-             base::FEATURE_ENABLED_BY_DEFAULT);
+             base::FEATURE_DISABLED_BY_DEFAULT);
 
 // Enables access to experimental WebXR features.
 BASE_FEATURE(kWebXrIncubations,

--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -368,6 +368,18 @@ struct VRDisplayState {
 #endif
 };
 
+struct VRHandJointData {
+  float transform[16];
+  float radius;
+};
+
+// https://www.w3.org/TR/webxr-hand-input-1/#skeleton-joints-section
+static const uint32_t kHandTrackingNumJoints = 25;
+
+struct VRHandTrackingData {
+  VRHandJointData handJointData[kHandTrackingNumJoints];
+};
+
 struct VRControllerState {
   char controllerName[kVRControllerNameMaxLen];
 #ifdef MOZILLA_INTERNAL_API
@@ -432,6 +444,9 @@ struct VRControllerState {
 
   bool isPositionValid;
   bool isOrientationValid;
+
+  bool hasHandTrackingData;
+  VRHandTrackingData handTrackingData;
 
 #ifdef MOZILLA_INTERNAL_API
   void Clear() { memset(this, 0, sizeof(VRControllerState)); }

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -117,8 +117,6 @@ device::Gamepad ToGamepad(const mozilla::gfx::VRControllerState& controller) {
     }
   }
 
-  // TODO: fill in hand tracking data here
-
   return builder.GetGamepad().value();
 }
 
@@ -386,7 +384,8 @@ void WvrManager::OnSubmitClientMojoConnectionError() {
 // for reference
 static void PopulateProfiles(
     device::mojom::XRInputSourceStatePtr& input_source,
-    const mozilla::gfx::VRControllerState& controller) {
+    const mozilla::gfx::VRControllerState& controller,
+    bool add_hand_profile) {
   switch (controller.type) {
     case mozilla::gfx::VRControllerType::HTCVive:
       input_source->description->profiles = {
@@ -452,6 +451,36 @@ static void PopulateProfiles(
       NOTREACHED();
       break;
   };
+
+  if (add_hand_profile)
+    input_source->description->profiles.push_back("generic-hand-select");
+}
+
+device::mojom::XRHandTrackingDataPtr
+GetHandTrackingData(const mozilla::gfx::VRControllerState& controller) {
+  if (!controller.hasHandTrackingData)
+    return nullptr;
+
+  auto hand_tracking_data = device::mojom::XRHandTrackingData::New();
+
+  hand_tracking_data->hand_joint_data.resize(mozilla::gfx::kHandTrackingNumJoints);
+
+  for (uint32_t i = 0; i < mozilla::gfx::kHandTrackingNumJoints; i++) {
+    auto hand_joint_dst = device::mojom::XRHandJointData::New();
+    auto& hand_joint_src = controller.handTrackingData.handJointData[i];
+
+    hand_joint_dst->joint = static_cast<device::mojom::XRHandJoint>(i);
+
+    gfx::Transform transform;
+    WvrMatToTransform(hand_joint_src.transform, &transform);
+    hand_joint_dst->mojo_from_joint.emplace(transform);
+
+    hand_joint_dst->radius = hand_joint_src.radius;
+
+    hand_tracking_data->hand_joint_data[i] = std::move(hand_joint_dst);
+  }
+
+  return hand_tracking_data;
 }
 
 std::vector<device::mojom::XRInputSourceStatePtr>
@@ -503,7 +532,7 @@ WvrManager::GetInputSourceState() {
             ? device::mojom::XRHandedness::LEFT
             : device::mojom::XRHandedness::RIGHT;
 
-    PopulateProfiles(input_source, controller);
+    PopulateProfiles(input_source, controller, controller.hasHandTrackingData);
 
     input_source->gamepad = ToGamepad(controller);
 
@@ -532,6 +561,8 @@ WvrManager::GetInputSourceState() {
             mozilla::gfx::ControllerCapabilityFlags::Cap_GripSpacePosition)) {
       input_source->mojo_from_input = WvrPoseToTransform(&controller.pose);
     }
+
+    input_source->hand_tracking_data = GetHandTrackingData(controller);
 
     input_sources.push_back(std::move(input_source));
   }

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -117,6 +117,9 @@ device::Gamepad ToGamepad(const mozilla::gfx::VRControllerState& controller) {
     }
   }
 
+  // TODO: Fill Gamepad data when there are no controllers, e.g during hand-tracking
+  //       https://www.w3.org/TR/webxr-gamepads-module-1/#gamepad-api-integration
+
   return builder.GetGamepad().value();
 }
 


### PR DESCRIPTION
https://www.w3.org/TR/webxr-hand-input-1/

Since the support is already present in blink, we just need to fetch the hand-tracking data pushed to us as part of system state updates, and populate it in the corresponding mojom data structures.

We also need to advertise the `generic-hand-select` profile in the input source description, as required by the spec.
