### PR TITLE
Wolvic: Fix time delta value in XR frame data

### DIFF
--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -593,7 +593,6 @@ void WvrManager::GetFrameData(
     return;
   }
 
-  pending_time_ = base::TimeTicks();
   get_frame_data_callback_ = std::move(callback);
   WebXrTryStartAnimatingFrame();
 }
@@ -605,6 +604,7 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
     return;
   }
 
+  base::TimeTicks now = base::TimeTicks::Now();
   device::mojom::XRFrameDataPtr frame_data = device::mojom::XRFrameData::New();
 
   frame_data->frame_id = webxr_.StartFrameAnimating();
@@ -624,7 +624,7 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
 
   frame_data->mojo_from_viewer = PoseToVRPosePtr(pose);
 
-  frame_data->time_delta = pending_time_ - base::TimeTicks();
+  frame_data->time_delta = now - base::TimeTicks();
 
   std::move(get_frame_data_callback_).Run(std::move(frame_data));
 }

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -604,15 +604,14 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
     return;
   }
 
-  base::TimeTicks now = base::TimeTicks::Now();
   device::mojom::XRFrameDataPtr frame_data = device::mojom::XRFrameData::New();
-
   frame_data->frame_id = webxr_.StartFrameAnimating();
 
   // Process all events.
   if (!SubmitFrameInternal(frame_data->frame_id))
    return;
 
+  base::TimeTicks now = base::TimeTicks::Now();
   mozilla::gfx::VRSystemState system_state = wvr_api_->get_system_state();
   const mozilla::gfx::VRPose* pose = &system_state.sensorState.pose;
 

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -117,7 +117,6 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   void ClosePresentationBindings();
   void OnSubmitClientMojoConnectionError();
 
-  base::TimeTicks pending_time_;
   device::mojom::XRFrameDataProvider::GetFrameDataCallback
       get_frame_data_callback_;
 


### PR DESCRIPTION
Time delta was being computed only once, during WebXR session initialization, resulting in fixed timestamps being forwarded to the apps. This would break those VR experiences using timestamp during rAF.

In order to fix that, this changes the WebXrTryStartAnimatingFrame to compute time delta every time this method runs.