### PR TITLE
Notify the creation of a new window

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -36,8 +36,6 @@ shared_library("libcontent_native") {
     "browser/session_settings.cc",
     "browser/session_settings.h",
     "browser/session_settings_jni.cc",
-    "browser/wolvic_contents.cc",
-    "browser/wolvic_contents.h",
     "browser/tab_jni.cc",
     "browser/vr/moz_external_vr.h",
     "browser/vr/wolvic_xr_integration_client.cc",
@@ -54,6 +52,10 @@ shared_library("libcontent_native") {
     "browser/vr/wvr_manager.h",
     "browser/vr/wvr_thread.cc",
     "browser/vr/wvr_thread.h",
+    "browser/wolvic_contents.cc",
+    "browser/wolvic_contents.h",
+    "browser/wolvic_web_contents_delegate.cc",
+    "browser/wolvic_web_contents_delegate.h",
     "renderer/browser_exposed_renderer_interfaces.cc",
     "renderer/browser_exposed_renderer_interfaces.h",
     "renderer/wolvic_content_renderer_client.cc",
@@ -214,6 +216,7 @@ generate_jni("jni_headers") {
     "java/org/chromium/wolvic/Tab.java",
     "java/org/chromium/wolvic/VRManager.java",
     "java/org/chromium/wolvic/WVRSurfaceTexture.java",
+    "java/org/chromium/wolvic/WolvicWebContentsDelegate.java",
   ]
 }
 
@@ -225,6 +228,7 @@ android_library("wolvic_java") {
     "java/org/chromium/wolvic/TabCompositorView.java",
     "java/org/chromium/wolvic/VRManager.java",
     "java/org/chromium/wolvic/WVRSurfaceTexture.java",
+    "java/org/chromium/wolvic/WolvicWebContentsDelegate.java",
   ]
   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
   deps = [

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -16,7 +16,6 @@
 using base::android::JavaParamRef;
 using base::android::ScopedJavaLocalRef;
 using content::WebContents;
-using web_contents_delegate_android::WebContentsDelegateAndroid;
 
 namespace wolvic {
 
@@ -45,13 +44,14 @@ void JNI_Tab_SetWebContentsDelegate(
     const JavaParamRef<jobject>& jweb_contents,
     const JavaParamRef<jobject>& jweb_contents_delegate) {
   WebContents* web_contents = WebContents::FromJavaWebContents(jweb_contents);
-  static std::unique_ptr<WebContentsDelegateAndroid> web_contents_delegate;
-
   DCHECK(web_contents);
 
-  web_contents_delegate =
-      std::make_unique<WebContentsDelegateAndroid>(env, jweb_contents_delegate);
-  web_contents->SetDelegate(web_contents_delegate.get());
+  auto* wolvic_contents = WolvicContents::FromWebContents(web_contents);
+  DCHECK(wolvic_contents);
+
+  auto web_contents_delegate =
+    std::make_unique<web_contents_delegate_android::WebContentsDelegateAndroid>(env, jweb_contents_delegate);
+  wolvic_contents->SetDelegate(std::move(web_contents_delegate));
 }
 
 }  // namespace wolvic

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -4,12 +4,12 @@
 
 #include "wolvic/jni_headers/Tab_jni.h"
 
-#include "components/embedder_support/android/delegate/web_contents_delegate_android.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/web_contents.h"
 #include "url/gurl.h"
 #include "wolvic/browser/wolvic_contents.h"
+#include "wolvic/browser/wolvic_web_contents_delegate.h"
 #include "wolvic/wolvic_browser_context.h"
 #include "wolvic/wolvic_content_browser_client.h"
 
@@ -47,10 +47,8 @@ void JNI_Tab_SetWebContentsDelegate(
   DCHECK(web_contents);
 
   auto* wolvic_contents = WolvicContents::FromWebContents(web_contents);
-  DCHECK(wolvic_contents);
-
   auto web_contents_delegate =
-    std::make_unique<web_contents_delegate_android::WebContentsDelegateAndroid>(env, jweb_contents_delegate);
+      std::make_unique<WolvicWebContentsDelegate>(env, jweb_contents_delegate);
   wolvic_contents->SetDelegate(std::move(web_contents_delegate));
 }
 

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -32,10 +32,12 @@ ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
           is_off_the_record ? browser_client->off_the_record_browser_context()
                             : browser_client->browser_context()));
 
-  auto wolvic_contents = std::make_unique<WolvicContents>(web_contents.get());
+  auto* web_contents_impl = web_contents.get();
+  auto wolvic_contents =
+      std::make_unique<WolvicContents>(std::move(web_contents));
   wolvic_contents.release()->Init();
 
-  return web_contents.release()->GetJavaWebContents();
+  return web_contents_impl->GetJavaWebContents();
 }
 
 void JNI_Tab_SetWebContentsDelegate(

--- a/wolvic/browser/wolvic_contents.cc
+++ b/wolvic/browser/wolvic_contents.cc
@@ -11,9 +11,9 @@
 #include "wolvic/wolvic_browser_context.h"
 #include "wolvic/wolvic_content_browser_client.h"
 
-namespace wolvic {
-
 using content::WebContents;
+
+namespace wolvic {
 
 const void* const kWolvicContentsUserDataKey = &kWolvicContentsUserDataKey;
 
@@ -35,6 +35,12 @@ class WolvicContentsUserData : public base::SupportsUserData::Data {
  private:
   std::unique_ptr<WolvicContents> contents_;
 };
+
+// static
+WolvicContents* WolvicContents::FromWebContents(WebContents* web_contents) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  return WolvicContentsUserData::GetContents(web_contents);
+}
 
 WolvicContents::WolvicContents(
     std::unique_ptr<content::WebContents> web_contents)
@@ -66,6 +72,12 @@ WolvicContents::DidFinishNavigation(content::NavigationHandle* navigation_handle
     content::WolvicBrowserContext::FromWebContents(*web_contents())
         ->AddVisitedURLs(navigation_handle->GetRedirectChain());
   }
+}
+
+void
+WolvicContents::SetDelegate(std::unique_ptr<web_contents_delegate_android::WebContentsDelegateAndroid> delegate) {
+  web_contents_delegate_ = std::move(delegate);
+  web_contents_->SetDelegate(web_contents_delegate_.get());
 }
 
 } // namespace wolvic

--- a/wolvic/browser/wolvic_contents.cc
+++ b/wolvic/browser/wolvic_contents.cc
@@ -47,6 +47,7 @@ WolvicContents::Init() {
 }
 
 WolvicContents::~WolvicContents() {
+  web_contents_->RemoveUserData(kWolvicContentsUserDataKey);
   WebContentsObserver::Observe(nullptr);
 }
 

--- a/wolvic/browser/wolvic_contents.cc
+++ b/wolvic/browser/wolvic_contents.cc
@@ -36,10 +36,10 @@ class WolvicContentsUserData : public base::SupportsUserData::Data {
   std::unique_ptr<WolvicContents> contents_;
 };
 
-WolvicContents::WolvicContents(content::WebContents* web_contents)
-    : content::WebContentsObserver(web_contents),
-      web_contents_(web_contents) {
-}
+WolvicContents::WolvicContents(
+    std::unique_ptr<content::WebContents> web_contents)
+    : content::WebContentsObserver(web_contents.get()),
+      web_contents_(std::move(web_contents)) {}
 
 void
 WolvicContents::Init() {

--- a/wolvic/browser/wolvic_contents.cc
+++ b/wolvic/browser/wolvic_contents.cc
@@ -10,6 +10,7 @@
 
 #include "wolvic/wolvic_browser_context.h"
 #include "wolvic/wolvic_content_browser_client.h"
+#include "wolvic/browser/wolvic_web_contents_delegate.h"
 
 using content::WebContents;
 
@@ -75,7 +76,7 @@ WolvicContents::DidFinishNavigation(content::NavigationHandle* navigation_handle
 }
 
 void
-WolvicContents::SetDelegate(std::unique_ptr<web_contents_delegate_android::WebContentsDelegateAndroid> delegate) {
+WolvicContents::SetDelegate(std::unique_ptr<WolvicWebContentsDelegate> delegate) {
   web_contents_delegate_ = std::move(delegate);
   web_contents_->SetDelegate(web_contents_delegate_.get());
 }

--- a/wolvic/browser/wolvic_contents.h
+++ b/wolvic/browser/wolvic_contents.h
@@ -5,12 +5,15 @@
 #ifndef WOLVIC_BROWSER_WOLVIC_CONTENTS_H_
 #define WOLVIC_BROWSER_WOLVIC_CONTENTS_H_
 
+#include "components/embedder_support/android/delegate/web_contents_delegate_android.h"
 #include "content/public/browser/web_contents_observer.h"
 
 namespace wolvic {
 
 class WolvicContents : public content::WebContentsObserver {
  public:
+  static WolvicContents* FromWebContents(content::WebContents* web_contents);
+
   WolvicContents(std::unique_ptr<content::WebContents> web_contents);
   void Init();
 
@@ -21,8 +24,11 @@ class WolvicContents : public content::WebContentsObserver {
 
   void DidFinishNavigation(content::NavigationHandle*) override;
 
+  void SetDelegate(std::unique_ptr<web_contents_delegate_android::WebContentsDelegateAndroid> delegate);
+
  private:
   std::unique_ptr<content::WebContents> web_contents_;
+  std::unique_ptr<web_contents_delegate_android::WebContentsDelegateAndroid> web_contents_delegate_;
 };
 
 }  // namespace content

--- a/wolvic/browser/wolvic_contents.h
+++ b/wolvic/browser/wolvic_contents.h
@@ -5,10 +5,11 @@
 #ifndef WOLVIC_BROWSER_WOLVIC_CONTENTS_H_
 #define WOLVIC_BROWSER_WOLVIC_CONTENTS_H_
 
-#include "components/embedder_support/android/delegate/web_contents_delegate_android.h"
 #include "content/public/browser/web_contents_observer.h"
 
 namespace wolvic {
+
+class WolvicWebContentsDelegate;
 
 class WolvicContents : public content::WebContentsObserver {
  public:
@@ -24,11 +25,11 @@ class WolvicContents : public content::WebContentsObserver {
 
   void DidFinishNavigation(content::NavigationHandle*) override;
 
-  void SetDelegate(std::unique_ptr<web_contents_delegate_android::WebContentsDelegateAndroid> delegate);
+  void SetDelegate(std::unique_ptr<WolvicWebContentsDelegate>);
 
  private:
   std::unique_ptr<content::WebContents> web_contents_;
-  std::unique_ptr<web_contents_delegate_android::WebContentsDelegateAndroid> web_contents_delegate_;
+  std::unique_ptr<WolvicWebContentsDelegate> web_contents_delegate_;
 };
 
 }  // namespace content

--- a/wolvic/browser/wolvic_contents.h
+++ b/wolvic/browser/wolvic_contents.h
@@ -11,7 +11,7 @@ namespace wolvic {
 
 class WolvicContents : public content::WebContentsObserver {
  public:
-  WolvicContents(content::WebContents* web_contents);
+  WolvicContents(std::unique_ptr<content::WebContents> web_contents);
   void Init();
 
   WolvicContents(const WolvicContents&) = delete;
@@ -22,7 +22,7 @@ class WolvicContents : public content::WebContentsObserver {
   void DidFinishNavigation(content::NavigationHandle*) override;
 
  private:
-  raw_ptr<content::WebContents> web_contents_;
+  std::unique_ptr<content::WebContents> web_contents_;
 };
 
 }  // namespace content

--- a/wolvic/browser/wolvic_web_contents_delegate.cc
+++ b/wolvic/browser/wolvic_web_contents_delegate.cc
@@ -1,0 +1,50 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/browser/wolvic_web_contents_delegate.h"
+
+#include "base/android/jni_android.h"
+#include "base/android/scoped_java_ref.h"
+#include "content/public/browser/web_contents.h"
+#include "wolvic/browser/wolvic_contents.h"
+#include "wolvic/jni_headers/WolvicWebContentsDelegate_jni.h"
+#include "url/android/gurl_android.h"
+
+namespace wolvic {
+
+WolvicWebContentsDelegate::WolvicWebContentsDelegate(JNIEnv* env, jobject obj)
+    : WebContentsDelegateAndroid(env, obj) {}
+
+WolvicWebContentsDelegate::~WolvicWebContentsDelegate() = default;
+
+using base::android::ScopedJavaLocalRef;
+
+// Called by web_contents_impl.cc whenever a navigation
+// requires the creation of a new window (for example
+// a link with target=_blank
+void WolvicWebContentsDelegate::AddNewContents(
+    content::WebContents* source,
+    std::unique_ptr<content::WebContents> new_contents,
+    const GURL& target_url,
+    WindowOpenDisposition disposition,
+    const blink::mojom::WindowFeatures& window_features,
+    bool user_gesture,
+    bool* was_blocked) {
+
+  JNIEnv* env = base::android::AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> java_delegate = GetJavaDelegate(env);
+  DCHECK(java_delegate.obj());
+
+  // We let new_contents die on purpouse (by not assigning the
+  // unique_ptr to any local variable/attribute because that way
+  // we are telling the web engine that we do not want a new
+  // window to be created. We'll in any case use the target_urlformatter
+  // to notify the client (Wolvic) so that it can create the window
+  // for the new URL on its own.
+  ScopedJavaLocalRef<jobject> java_gurl =
+      url::GURLAndroid::FromNativeGURL(env, target_url);
+  Java_WolvicWebContentsDelegate_onCreateNewWindow(env, java_delegate, java_gurl);
+}
+
+} // namespace wolvic

--- a/wolvic/browser/wolvic_web_contents_delegate.h
+++ b/wolvic/browser/wolvic_web_contents_delegate.h
@@ -1,0 +1,34 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WOLVIC_BROWSER_WOLVIC_WEB_CONTENTS_DELEGATE_H_
+#define WOLVIC_BROWSER_WOLVIC_WEB_CONTENTS_DELEGATE_H_
+
+#include "components/embedder_support/android/delegate/web_contents_delegate_android.h"
+
+namespace wolvic {
+
+class WolvicWebContentsDelegate
+    : public web_contents_delegate_android::WebContentsDelegateAndroid {
+ public:
+  WolvicWebContentsDelegate(JNIEnv* env, jobject obj);
+  ~WolvicWebContentsDelegate() override;
+
+  // See //android_webview/docs/how-does-on-create-window-work.md for more
+  // details.
+  void AddNewContents(content::WebContents* source,
+                      std::unique_ptr<content::WebContents> new_contents,
+                      const GURL& target_url,
+                      WindowOpenDisposition disposition,
+                      const blink::mojom::WindowFeatures& window_features,
+                      bool user_gesture,
+                      bool* was_blocked) final;
+
+ private:
+  std::unique_ptr<content::WebContents> new_contents_;
+};
+
+}// namespace wolvic
+
+#endif // WOLVIC_BROWSER_WOLVIC_WEB_CONTENTS_DELEGATE_H_

--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -11,7 +11,6 @@ import androidx.annotation.NonNull;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.components.embedder_support.delegate.WebContentsDelegateAndroid;
 import org.chromium.components.embedder_support.view.ContentView;
 import org.chromium.components.url_formatter.UrlFormatter;
 import org.chromium.content_public.browser.ImeAdapter;
@@ -21,6 +20,7 @@ import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.ActivityWindowAndroid;
 import org.chromium.ui.base.IntentRequestTracker;
 import org.chromium.ui.base.ViewAndroidDelegate;
+import org.chromium.wolvic.WolvicWebContentsDelegate;
 
 @JNINamespace("wolvic")
 public class Tab {
@@ -35,7 +35,7 @@ public class Tab {
     }
 
     public void setWebContentsDelegate(
-            WebContents webContents, WebContentsDelegateAndroid delegate) {
+            WebContents webContents, WolvicWebContentsDelegate delegate) {
         TabJni.get().setWebContentsDelegate(webContents, delegate);
     }
 
@@ -96,6 +96,6 @@ public class Tab {
     @NativeMethods
     public interface Natives {
         WebContents createWebContents(boolean is_off_the_record);
-        void setWebContentsDelegate(WebContents webContents, WebContentsDelegateAndroid delegate);
+        void setWebContentsDelegate(WebContents webContents, WolvicWebContentsDelegate delegate);
     }
 }

--- a/wolvic/java/org/chromium/wolvic/WolvicWebContentsDelegate.java
+++ b/wolvic/java/org/chromium/wolvic/WolvicWebContentsDelegate.java
@@ -1,0 +1,18 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.url.GURL;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.components.embedder_support.delegate.WebContentsDelegateAndroid;
+
+@JNINamespace("wolvic")
+public abstract class WolvicWebContentsDelegate extends WebContentsDelegateAndroid {
+    @CalledByNative
+    public abstract void onCreateNewWindow(GURL url);
+}


### PR DESCRIPTION
The main purpouse of this PR is to add a new notification method that would allow Wolvic to create a new window on its own when certain types of navigations (like links with `target=_blank`) instruct the web engine to create a new window.

This was done by subclassing `WebContentsDelegateAndroid` into a new class `WolvicWebContentsDelegate` with a single abstract method that should be implemented in Wolvic. That method carries the url that should be opened in the new window.

In order to let Wolvic create the window we first must ask chromium not to create a window for it. That's done by letting the `WebContents` created by Chromium die (normally the delegate should take ownership of it). When that happens Chromium automatically cancels the creation of a new window. Wolvic will still however get the notification and will create the new window by itself.

The reason why we don't use the `WebContents` created by chromium directly in Wolvic is because the current Wolvic architecture (designed mainly to fit well with GeckoView API) does not easily allow us to reuse it for a new session/tab.

The actual fix is the last commit in the series. There are 3 precuels that fixes some already existing issues in our implementation (without them the new method don't work properly).