### PR TITLE
Implement basic permissions support

### DIFF
--- a/content/browser/xr/service/vr_service_impl.cc
+++ b/content/browser/xr/service/vr_service_impl.cc
@@ -572,9 +572,6 @@ void VRServiceImpl::OnPermissionResultsForMode(
       permission_results.HasPermissionsFor(request.options->mode);
   DVLOG(2) << __func__ << ": is_consent_granted=" << is_consent_granted;
 
-  // TODO : Remove it after implementing Permission feature.
-  is_consent_granted = true;
-
   if (!is_consent_granted) {
     std::move(request.callback)
         .Run(device::mojom::RequestSessionResult::NewFailureReason(

--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -212,6 +212,7 @@ jinja_template("content_manifest") {
 generate_jni("jni_headers") {
   sources = [
     "java/org/chromium/wolvic/DownloadManagerBridge.java",
+    "java/org/chromium/wolvic/PermissionManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",
     "java/org/chromium/wolvic/VRManager.java",
@@ -223,6 +224,7 @@ generate_jni("jni_headers") {
 android_library("wolvic_java") {
   sources = [
     "java/org/chromium/wolvic/DownloadManagerBridge.java",
+    "java/org/chromium/wolvic/PermissionManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",
     "java/org/chromium/wolvic/TabCompositorView.java",

--- a/wolvic/java/org/chromium/wolvic/PermissionManagerBridge.java
+++ b/wolvic/java/org/chromium/wolvic/PermissionManagerBridge.java
@@ -98,25 +98,26 @@ public class PermissionManagerBridge {
                                            boolean isOffTheRecord,
                                            long inProgressRequestPtr) {
         PermissionManagerBridge bridge = get();
-        if (bridge.mDelegate != null) {
-            bridge.mDelegate.onPermissionRequest(
-                    Arrays.stream(permissionTypes)
-                            .mapToObj(PermissionType::fromValue)
-                            .toArray(PermissionType[]::new),
-                    url,
-                    isOffTheRecord,
-                    new PermissionCallback() {
-                        @Override
-                        public void onPermissionResult(PermissionStatus[] results) {
-                            PermissionManagerBridgeJni.get().onPermissionResult(
-                                    isOffTheRecord,
-                                    inProgressRequestPtr,
-                                    Arrays.stream(results)
-                                            .mapToInt(PermissionStatus::getValue)
-                                            .toArray());
-                        }
-                    });
+        if (bridge.mDelegate == null) {
+            return;
         }
+        bridge.mDelegate.onPermissionRequest(
+                Arrays.stream(permissionTypes)
+                        .mapToObj(PermissionType::fromValue)
+                        .toArray(PermissionType[]::new),
+                url,
+                isOffTheRecord,
+                new PermissionCallback() {
+                    @Override
+                    public void onPermissionResult(PermissionStatus[] results) {
+                        PermissionManagerBridgeJni.get().onPermissionResult(
+                                isOffTheRecord,
+                                inProgressRequestPtr,
+                                Arrays.stream(results)
+                                        .mapToInt(PermissionStatus::getValue)
+                                        .toArray());
+                    }
+        });
     }
 
     @NativeMethods

--- a/wolvic/java/org/chromium/wolvic/PermissionManagerBridge.java
+++ b/wolvic/java/org/chromium/wolvic/PermissionManagerBridge.java
@@ -1,0 +1,126 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import androidx.annotation.NonNull;
+
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+@JNINamespace("wolvic")
+public class PermissionManagerBridge {
+    public enum PermissionType {
+        GEOLOCATION(0),
+        DESKTOP_NOTIFICATION(1),
+        PERSISTENT_STORAGE(2),
+        XR(3),
+        AUTOPLAY_INAUDIBLE(4),
+        AUTOPLAY_AUDIBLE(5),
+        MEDIA_KEY_SYSTEM_ACCESS(6),
+        TRACKING(7),
+        STORAGE_ACCESS(8),
+
+        // Any chromium permissions that are not yet supported by Wolvic are
+        // mapped into this value and automatically denied.
+        NOT_SUPPORTED(9);
+
+        public static final PermissionType[] types = PermissionType.values();
+
+        private final int value;
+
+        private PermissionType(int value) {
+            this.value = value;
+        }
+
+        private static PermissionType fromValue(int value) {
+            return types[value];
+        }
+
+        private int getValue() {
+            return value;
+        }
+
+    }
+
+    public enum PermissionStatus {
+        PROMPT(0),
+        DENY(1),
+        ALLOW(2);
+
+        public static final PermissionStatus[] statuses = PermissionStatus.values();
+
+        private final int value;
+
+        private PermissionStatus(int value) {
+            this.value = value;
+        }
+
+        private static PermissionStatus fromValue(int value) {
+            return statuses[value];
+        }
+
+        private int getValue() {
+            return value;
+        }
+    }
+
+    public interface PermissionCallback {
+        void onPermissionResult(PermissionStatus[] results);
+    }
+
+    public interface Delegate {
+        void onPermissionRequest(PermissionType[] permissionTypes, String url,
+                                 boolean isOffTheRecord, PermissionCallback callback);
+    }
+    
+    private static PermissionManagerBridge sInstance;
+    private Delegate mDelegate;
+
+    public static PermissionManagerBridge get() {
+        if (sInstance == null) {
+            sInstance = new PermissionManagerBridge();
+        }
+        return sInstance;
+    }
+
+    public void setDelegate(@NonNull Delegate delegate) {
+        mDelegate = delegate;
+    }
+
+    @CalledByNative
+    public static void onPermissionRequest(int[] permissionTypes, String url,
+                                           boolean isOffTheRecord,
+                                           long inProgressRequestPtr) {
+        PermissionManagerBridge bridge = get();
+        if (bridge.mDelegate != null) {
+            bridge.mDelegate.onPermissionRequest(
+                    Arrays.stream(permissionTypes)
+                            .mapToObj(PermissionType::fromValue)
+                            .toArray(PermissionType[]::new),
+                    url,
+                    isOffTheRecord,
+                    new PermissionCallback() {
+                        @Override
+                        public void onPermissionResult(PermissionStatus[] results) {
+                            PermissionManagerBridgeJni.get().onPermissionResult(
+                                    isOffTheRecord,
+                                    inProgressRequestPtr,
+                                    Arrays.stream(results)
+                                            .mapToInt(PermissionStatus::getValue)
+                                            .toArray());
+                        }
+                    });
+        }
+    }
+
+    @NativeMethods
+    public interface Natives {
+        void onPermissionResult(boolean isOffTheRecord, long inProgressRequestPtr, int[] results);
+    }
+}

--- a/wolvic/wolvic_permission_manager.cc
+++ b/wolvic/wolvic_permission_manager.cc
@@ -4,52 +4,153 @@
 
 #include "wolvic/wolvic_permission_manager.h"
 
+#include <jni.h>
+#include <algorithm>
+#include <memory>
+#include <span>
+
+#include "base/android/jni_array.h"
+#include "base/android/jni_string.h"
+#include "base/android/scoped_java_ref.h"
+#include "base/notreached.h"
 #include "components/permissions/permission_util.h"
 #include "content/public/browser/browser_context.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/permission_request_description.h"
+#include "content/public/browser/permission_result.h"
 #include "content/public/browser/render_frame_host.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
 #include "url/gurl.h"
 #include "url/origin.h"
+#include "wolvic/jni_headers/PermissionManagerBridge_jni.h"
 
-// TODO(zvoit): Current implementation automatically denies any requested
-// permissions except for PROTECTED_MEDIA_IDENTIFIER. This code should show
-// Wolvic's permission request dialog instead.
-
+namespace wolvic {
 namespace {
 
-bool IsAllowlistedPermissionType(blink::PermissionType permission) {
+// Has to be kept in sync with PermissionManagerBridge.java
+enum class WolvicPermissionType {
+  kGeolocation = 0,
+  kDesktopNotification = 1,
+  kPersistentStorage = 2,
+  kXr = 3,
+  kAutoplayInaudible = 4,
+  kAutoplayAudible = 5,
+  kMediaKeySystemAccess = 6,
+  kTracking = 7,
+  kStorageAccess = 8,
+
+  kNotSupported = 9,
+};
+
+// Has to be kept in sync with PermissionManagerBridge.java
+enum class WolvicPermissionStatus {
+  kPrompt = 0,
+  kDeny = 1,
+  kAllow = 2,
+};
+
+WolvicPermissionType ToWolvicPermissionType(blink::PermissionType permission) {
   switch (permission) {
+    case blink::PermissionType::GEOLOCATION:
+      return WolvicPermissionType::kGeolocation;
+    case blink::PermissionType::NOTIFICATIONS:
+      return WolvicPermissionType::kDesktopNotification;
+    case blink::PermissionType::DURABLE_STORAGE:
+      return WolvicPermissionType::kPersistentStorage;
+    case blink::PermissionType::VR:
+    case blink::PermissionType::AR:
+      return WolvicPermissionType::kXr;
     case blink::PermissionType::PROTECTED_MEDIA_IDENTIFIER:
-      return true;
+      return WolvicPermissionType::kMediaKeySystemAccess;
+    case blink::PermissionType::STORAGE_ACCESS_GRANT:
+      return WolvicPermissionType::kStorageAccess;
     default:
-      return false;
+      // TODO(voit): Where to we get kAutoplayInaudible, kAutoplayAudible and
+      // kTracking from?
+      return WolvicPermissionType::kNotSupported;
   }
 
   NOTREACHED();
-  return false;
+  return WolvicPermissionType::kNotSupported;
 }
 
-blink::mojom::PermissionStatus GrantOrDenyPermission(
-    blink::PermissionType permission) {
-  return IsAllowlistedPermissionType(permission)
-             ? blink::mojom::PermissionStatus::GRANTED
-             : blink::mojom::PermissionStatus::DENIED;
+content::PermissionStatus FromWolvicPermissionStatus(
+    WolvicPermissionStatus status) {
+  switch (status) {
+    case WolvicPermissionStatus::kPrompt:
+      return content::PermissionStatus::ASK;
+    case WolvicPermissionStatus::kDeny:
+      return content::PermissionStatus::DENIED;
+    case WolvicPermissionStatus::kAllow:
+      return content::PermissionStatus::GRANTED;
+  }
+
+  NOTREACHED();
+  return content::PermissionStatus::DENIED;
+}
+
+std::vector<int> ToJavaWolvicPermissionTypes(
+    const std::vector<blink::PermissionType>& permissions) {
+  std::vector<int> result(permissions.size());
+  for (size_t i = 0; i < permissions.size(); ++i) {
+    result[i] = static_cast<int>(ToWolvicPermissionType(permissions[i]));
+  }
+  return result;
+}
+
+std::vector<content::PermissionStatus> FromJavaWolvicPermissionStatuses(
+    const std::vector<int>& statuses) {
+  std::vector<content::PermissionStatus> result(statuses.size());
+  for (size_t i = 0; i < statuses.size(); ++i) {
+    result[i] = FromWolvicPermissionStatus(
+        static_cast<WolvicPermissionStatus>(statuses[i]));
+  }
+  return result;
+}
+
+wolvic::WolvicPermissionManager* g_instance = nullptr;
+wolvic::WolvicPermissionManager* g_off_the_record_instance = nullptr;
+
+WolvicPermissionManager* GetPermissionManager() {
+  DCHECK(g_instance);
+  return g_instance;
+}
+
+WolvicPermissionManager* GetOffTheRecordPermissionManager() {
+  DCHECK(g_off_the_record_instance);
+  return g_off_the_record_instance;
 }
 
 }  // namespace
 
-namespace wolvic {
+InProgressRequest::InProgressRequest(
+    base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
+        callback)
+    : callback(std::move(callback)) {}
+
+InProgressRequest::~InProgressRequest() = default;
 
 WolvicPermissionManager::WolvicPermissionManager(
     content::BrowserContext* browser_context)
-    : browser_context_(browser_context) {}
+    : browser_context_(browser_context) {
+  if (browser_context_->IsOffTheRecord()) {
+    DCHECK(!g_off_the_record_instance);
+    g_off_the_record_instance = this;
+  } else {
+    DCHECK(!g_instance);
+    g_instance = this;
+  }
+}
+
+WolvicPermissionManager::~WolvicPermissionManager() = default;
 
 void WolvicPermissionManager::RequestPermissions(
     content::RenderFrameHost* render_frame_host,
     const content::PermissionRequestDescription& request_description,
     base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
         callback) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
   if (render_frame_host->IsNestedWithinFencedFrame()) {
     std::move(callback).Run(std::vector<blink::mojom::PermissionStatus>(
         request_description.permissions.size(),
@@ -57,12 +158,23 @@ void WolvicPermissionManager::RequestPermissions(
     return;
   }
 
-  std::vector<blink::mojom::PermissionStatus> result;
-  for (const auto& permission : request_description.permissions) {
-    result.push_back(GrantOrDenyPermission(permission));
-  }
+  JNIEnv* env = base::android::AttachCurrentThread();
 
-  std::move(callback).Run(result);
+  auto url_java_string = base::android::ScopedJavaGlobalRef<jstring>(
+      base::android::ConvertUTF8ToJavaString(
+          env, request_description.requesting_origin.spec()));
+  auto permissions =
+      ToJavaWolvicPermissionTypes(request_description.permissions);
+  auto permissions_java_array = base::android::ScopedJavaGlobalRef<jintArray>(
+      base::android::ToJavaIntArray(
+          env, std::span(permissions.begin(), permissions.end())));
+
+  in_progress_requests_.emplace_back(
+      std::make_unique<InProgressRequest>(std::move(callback)));
+  Java_PermissionManagerBridge_onPermissionRequest(
+      env, permissions_java_array, url_java_string,
+      browser_context_->IsOffTheRecord(),
+      reinterpret_cast<jlong>(in_progress_requests_.back().get()));
 }
 
 void WolvicPermissionManager::ResetPermission(blink::PermissionType permission,
@@ -82,7 +194,9 @@ blink::mojom::PermissionStatus WolvicPermissionManager::GetPermissionStatus(
     blink::PermissionType permission,
     const GURL& requesting_origin,
     const GURL& embedding_origin) {
-  return GrantOrDenyPermission(permission);
+  // We don't save any permissions statuses on Chromium side, so return 'ASK'
+  // here to make sure that any permissions are requested from Wolvic.
+  return blink::mojom::PermissionStatus::ASK;
 }
 
 content::PermissionResult
@@ -146,5 +260,39 @@ WolvicPermissionManager::SubscribePermissionStatusChange(
 
 void WolvicPermissionManager::UnsubscribePermissionStatusChange(
     SubscriptionId subscription_id) {}
+
+void WolvicPermissionManager::OnPermissionResult(
+    InProgressRequest* in_progress_request,
+    const std::vector<content::PermissionStatus>& result) {
+  auto it = std::find_if(in_progress_requests_.begin(),
+                         in_progress_requests_.end(), [&](const auto& request) {
+                           return request.get() == in_progress_request;
+                         });
+  CHECK(it != in_progress_requests_.end());
+  std::move((*it)->callback).Run(result);
+  in_progress_requests_.erase(it);
+}
+
+static void JNI_PermissionManagerBridge_OnPermissionResult(
+    JNIEnv* env,
+    jboolean is_off_the_record,
+    jlong in_progress_request_ptr,
+    const base::android::JavaParamRef<jintArray>& results) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  auto* in_progress_request =
+      reinterpret_cast<InProgressRequest*>(in_progress_request_ptr);
+
+  std::vector<int> java_permission_results;
+  base::android::JavaIntArrayToIntVector(env, results,
+                                         &java_permission_results);
+
+  auto* permission_manager = is_off_the_record
+                                 ? GetOffTheRecordPermissionManager()
+                                 : GetPermissionManager();
+  permission_manager->OnPermissionResult(
+      in_progress_request,
+      FromJavaWolvicPermissionStatuses(java_permission_results));
+}
 
 }  // namespace wolvic

--- a/wolvic/wolvic_permission_manager.h
+++ b/wolvic/wolvic_permission_manager.h
@@ -5,15 +5,30 @@
 #ifndef WOLVIC_WOLVIC_PERMISSION_MANAGER_H_
 #define WOLVIC_WOLVIC_PERMISSION_MANAGER_H_
 
+#include "base/containers/unique_ptr_adapters.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/permission_controller_delegate.h"
+#include "content/public/browser/permission_request_description.h"
+#include "content/public/browser/permission_result.h"
 
 namespace wolvic {
+
+// Holds callbacks for in-progress permission requests.
+struct InProgressRequest {
+  explicit InProgressRequest(
+      base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
+          callback);
+
+  ~InProgressRequest();
+
+  base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
+      callback;
+};
 
 class WolvicPermissionManager : public content::PermissionControllerDelegate {
  public:
   explicit WolvicPermissionManager(content::BrowserContext* browser_context);
-  ~WolvicPermissionManager() override = default;
+  ~WolvicPermissionManager() override;
 
   // PermissionControllerDelegate overrides:
   void RequestPermissions(
@@ -58,8 +73,13 @@ class WolvicPermissionManager : public content::PermissionControllerDelegate {
   void UnsubscribePermissionStatusChange(
       SubscriptionId subscription_id) override;
 
+  void OnPermissionResult(InProgressRequest* in_progress_request,
+                          const std::vector<content::PermissionStatus>& result);
+
  private:
   raw_ptr<content::BrowserContext> browser_context_;
+
+  std::vector<std::unique_ptr<InProgressRequest>> in_progress_requests_;
 };
 
 }  // namespace wolvic


### PR DESCRIPTION
This change requires M118 branch due to significant changes in Chromium permission interfaces.

Forward permission requests to Wolvic to show the permission request user dialog. This change only supports several basic permissions, support for more advanced things like media permissions will be added later.