### PR TITLE
Add an extra null check in LoadingStateChanged

### DIFF
--- a/wolvic/browser/wolvic_web_contents_delegate.cc
+++ b/wolvic/browser/wolvic_web_contents_delegate.cc
@@ -47,4 +47,17 @@ void WolvicWebContentsDelegate::AddNewContents(
   Java_WolvicWebContentsDelegate_onCreateNewWindow(env, java_delegate, java_gurl);
 }
 
+// This adds an extra null check to the parent's behaviour. Seems to be needed
+// in some architectures, otherwise it crashes. This started to be observed in
+// Meta's Quest3 after the M118 update
+void WolvicWebContentsDelegate::LoadingStateChanged(
+    content::WebContents* source,
+    bool should_show_loading_ui) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> obj = GetJavaDelegate(env);
+  if (obj.is_null())
+    return;
+  WebContentsDelegateAndroid::LoadingStateChanged(source, should_show_loading_ui);
+}
+
 } // namespace wolvic

--- a/wolvic/browser/wolvic_web_contents_delegate.h
+++ b/wolvic/browser/wolvic_web_contents_delegate.h
@@ -15,6 +15,9 @@ class WolvicWebContentsDelegate
   WolvicWebContentsDelegate(JNIEnv* env, jobject obj);
   ~WolvicWebContentsDelegate() override;
 
+  void LoadingStateChanged(content::WebContents* source,
+                           bool should_show_loading_ui) override;
+
   // See //android_webview/docs/how-does-on-create-window-work.md for more
   // details.
   void AddNewContents(content::WebContents* source,


### PR DESCRIPTION
This fixes a crash that we started to observe in Quest3 devices after upgrading to M118. This null check is present in almost all the WebContentsDelegateAndroid methods but not in the LoadingStateChanged. Perhaps it's a precondition of the call and we're hitting a bug in some untested code path.