### PR TITLE
Add Meta Quest3 WebXR input profile

### DIFF
--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -154,6 +154,7 @@ enum class VRControllerType : uint8_t {
   PicoG2,
   PicoNeo2,
   Pico4,
+  MetaQuest3,
   _end
 };
 

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -434,6 +434,11 @@ static void PopulateProfiles(
           "oculus-touch-v3", "oculus-touch-v2", "oculus-touch",
           "generic-trigger-squeeze-thumbstick"};
       break;
+    case mozilla::gfx::VRControllerType::MetaQuest3:
+      input_source->description->profiles = {
+          "meta-quest-touch-plus", "oculus-touch-v3", "oculus-touch",
+          "generic-trigger-squeeze-thumbstick"};
+      break;
     case mozilla::gfx::VRControllerType::PicoG2:
       input_source->description->profiles = {
           "pico-g2", "generic-trigger-squeeze-thumbstick"};


### PR DESCRIPTION
We need to map the device type coming from Wolvic to a list of supported WebXR input profiles. This way WebXR experiences can properly render the 3D model of the actual controllers.