### PR TITLE
Add MagicLeap 2 WebXR input profile

### DIFF
--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -155,6 +155,7 @@ enum class VRControllerType : uint8_t {
   PicoNeo2,
   Pico4,
   MetaQuest3,
+  MagicLeap2,
   _end
 };
 

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -455,6 +455,10 @@ static void PopulateProfiles(
     case mozilla::gfx::VRControllerType::_empty:
       input_source->description->profiles = {"generic-button"};
       break;
+    case mozilla::gfx::VRControllerType::MagicLeap2:
+      input_source->description->profiles = {
+	"magicleap-one", "generic-trigger-squeeze-touchpad"};
+      break;
     case mozilla::gfx::VRControllerType::_end:
       NOTREACHED();
       break;


### PR DESCRIPTION
We need to map the device type coming from Wolvic to a list of supported WebXR input profiles. This way WebXR experiences can properly render the 3D model of the actual controllers.