### PR TITLE
Use generic-hand profile instead of generic-hand-select

### DIFF
--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -461,7 +461,7 @@ static void PopulateProfiles(
   };
 
   if (add_hand_profile)
-    input_source->description->profiles.push_back("generic-hand-select");
+    input_source->description->profiles.insert(input_source->description->profiles.begin(), "generic-hand");
 }
 
 device::mojom::XRHandTrackingDataPtr


### PR DESCRIPTION
The former does have a 3D model in the WebXR repository while the latter don't, that's why we don't show the hand model correctly in some experiences.

Apart from that do insert the hand profile at the beginning of the list of profiles. Otherwise the physical controller profile would be selected first.