### PR TITLE
Set XR Space parameters

### DIFF
--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -44,6 +44,12 @@ device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
   return pose;
 }
 
+gfx::Transform GetFloorTransform(const float matrix[16]) {
+  gfx::Transform transform;
+  WvrMatToTransform(matrix, &transform);
+  return transform.GetCheckedInverse();
+}
+
 device::mojom::XRHandedness ToXRHandness(mozilla::gfx::ControllerHand hand) {
   using mozilla::gfx::ControllerHand;
   switch (hand) {
@@ -667,6 +673,15 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
   frame_data->mojo_from_viewer = PoseToVRPosePtr(pose);
 
   frame_data->time_delta = now - base::TimeTicks();
+
+  gfx::Transform transform = GetFloorTransform(system_state.displayState.sittingToStandingTransform);
+  if (floor_transform_ != transform) {
+    frame_data->stage_parameters_id = ++stage_parameters_id_;
+    floor_transform_ = transform;
+  }
+
+  frame_data->stage_parameters = device::mojom::VRStageParameters::New();
+  frame_data->stage_parameters->mojo_from_floor = floor_transform_;
 
   std::move(get_frame_data_callback_).Run(std::move(frame_data));
 }

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -120,6 +120,9 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   device::mojom::XRFrameDataProvider::GetFrameDataCallback
       get_frame_data_callback_;
 
+  gfx::Transform floor_transform_;
+  uint32_t stage_parameters_id_ = 0;
+
   // Communicate with the renderer.
   mojo::Receiver<device::mojom::XRPresentationProvider> presentation_receiver_{
       this};


### PR DESCRIPTION
Wonderland Engine used in SpraySpace VR requires the XRSpace parameters and updates XR frames if these parameters are valid. We couldn't get any XRframe since we delivered the null value for it.

This patch sets them when GetFrameData's callback is called.

And, |stage_parameters_id_| increments the count only when there is an actual change, so that Blink uses the cached values if there is no change.

Fixes https://github.com/Igalia/wolvic-chromium/issues/58