### PR TITLE
Add PageZoom APIs in Tab

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -83,6 +83,7 @@ shared_library("libcontent_native") {
   deps = [
     ":content_native_lib",
     ":jni_headers",
+    "//components/zoom",
     "//components/crash/content/browser",
     "//device/vr:vr_util",
     "//media",

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -4,9 +4,12 @@
 
 #include "wolvic/jni_headers/Tab_jni.h"
 
+#include "components/zoom/page_zoom.h"
+#include "components/zoom/zoom_controller.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/common/page_zoom.h"
 #include "url/gurl.h"
 #include "wolvic/browser/wolvic_contents.h"
 #include "wolvic/browser/wolvic_web_contents_delegate.h"
@@ -18,6 +21,17 @@ using base::android::ScopedJavaLocalRef;
 using content::WebContents;
 
 namespace wolvic {
+
+namespace {
+
+void doPageZoom(const JavaParamRef<jobject>& jweb_contents,
+                content::PageZoom zoom) {
+  WebContents* web_contents = WebContents::FromJavaWebContents(jweb_contents);
+  DCHECK(web_contents);
+  zoom::PageZoom::Zoom(web_contents, zoom);
+}
+
+}  // namespace
 
 ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
     JNIEnv* env,
@@ -36,6 +50,8 @@ ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
       std::make_unique<WolvicContents>(std::move(web_contents));
   wolvic_contents.release()->Init();
 
+  zoom::ZoomController::CreateForWebContents(web_contents_impl);
+
   return web_contents_impl->GetJavaWebContents();
 }
 
@@ -50,6 +66,31 @@ void JNI_Tab_SetWebContentsDelegate(
   auto web_contents_delegate =
       std::make_unique<WolvicWebContentsDelegate>(env, jweb_contents_delegate);
   wolvic_contents->SetDelegate(std::move(web_contents_delegate));
+}
+
+void JNI_Tab_PageZoomIn(JNIEnv* env,
+                        const JavaParamRef<jobject>& jweb_contents) {
+  doPageZoom(jweb_contents, content::PAGE_ZOOM_IN);
+}
+
+void JNI_Tab_PageZoomOut(JNIEnv* env,
+                         const JavaParamRef<jobject>& jweb_contents) {
+  doPageZoom(jweb_contents, content::PAGE_ZOOM_OUT);
+}
+
+void JNI_Tab_PageZoomReset(JNIEnv* env,
+                           const JavaParamRef<jobject>& jweb_contents) {
+  doPageZoom(jweb_contents, content::PAGE_ZOOM_RESET);
+}
+
+jint JNI_Tab_GetCurrentZoomLevel(JNIEnv* env,
+                                 const JavaParamRef<jobject>& jweb_contents) {
+  WebContents* web_contents = WebContents::FromJavaWebContents(jweb_contents);
+  DCHECK(web_contents);
+
+  zoom::ZoomController* zoom_controller =
+      zoom::ZoomController::FromWebContents(web_contents);
+  return zoom_controller->GetZoomPercent();
 }
 
 }  // namespace wolvic

--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import org.chromium.base.ContextUtils;
+import org.chromium.base.ThreadUtils;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
 import org.chromium.components.embedder_support.view.ContentView;
@@ -93,9 +94,37 @@ public class Tab {
         return ImeAdapter.fromWebContents(mWebContents);
     }
 
+    public void pageZoomIn() {
+        ThreadUtils.runOnUiThread(() -> {
+            TabJni.get().pageZoomIn(mWebContents);
+        });
+    }
+
+    public void pageZoomOut() {
+        ThreadUtils.runOnUiThread(() -> {
+            TabJni.get().pageZoomOut(mWebContents);
+        });
+    }
+
+    public void pageZoomReset() {
+        ThreadUtils.runOnUiThread(() -> {
+            TabJni.get().pageZoomReset(mWebContents);
+        });
+    }
+
+    public int getCurrentZoomLevel() {
+        return ThreadUtils.runOnUiThreadBlockingNoException(() -> {
+            return TabJni.get().getCurrentZoomLevel(mWebContents);
+        });
+    }
+
     @NativeMethods
     public interface Natives {
         WebContents createWebContents(boolean is_off_the_record);
         void setWebContentsDelegate(WebContents webContents, WolvicWebContentsDelegate delegate);
+        void pageZoomIn(WebContents webContents);
+        void pageZoomOut(WebContents webContents);
+        void pageZoomReset(WebContents webContents);
+        int getCurrentZoomLevel(WebContents webContents);
     }
 }


### PR DESCRIPTION
The zoom factor map exists separately for Android and Desktop. This patch accesses the native PageZoom code to use desktop's zoom factor map. These APIs added in Tab will be used in the Zoom UI.