### PR TITLE
Add setFactory for DateTime Prompt

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/input/DateTimeChooserAndroid.java
+++ b/content/public/android/java/src/org/chromium/content/browser/input/DateTimeChooserAndroid.java
@@ -18,14 +18,25 @@ import org.chromium.ui.base.WindowAndroid;
  * Plumbing for the different date/time dialog adapters.
  */
 @JNINamespace("content")
-class DateTimeChooserAndroid {
+public class DateTimeChooserAndroid {
     private long mNativeDateTimeChooserAndroid;
     private final InputDialogContainer mInputDialogContainer;
 
+    public interface Factory {
+        public InputDialogContainer create(Context context, InputDialogContainer.InputActionDelegate delegate);
+    }
+
+    private static Factory sFactory;
+
+    public static void setFactory(Factory factory) {
+        sFactory = factory;
+    }
+
     private DateTimeChooserAndroid(Context context, long nativeDateTimeChooserAndroid) {
         mNativeDateTimeChooserAndroid = nativeDateTimeChooserAndroid;
-        mInputDialogContainer =
-                new InputDialogContainer(context, new InputDialogContainer.InputActionDelegate() {
+
+        InputDialogContainer.InputActionDelegate delegate =
+                new InputDialogContainer.InputActionDelegate() {
                     @Override
                     public void replaceDateTime(double value) {
                         if (mNativeDateTimeChooserAndroid == 0) {
@@ -43,7 +54,14 @@ class DateTimeChooserAndroid {
                         DateTimeChooserAndroidJni.get().cancelDialog(
                                 mNativeDateTimeChooserAndroid, DateTimeChooserAndroid.this);
                     }
-                });
+                };
+
+        if (sFactory != null) {
+            mInputDialogContainer = sFactory.create(context, delegate);
+        } else {
+            mInputDialogContainer =
+                    new InputDialogContainer(context, delegate);
+        }
     }
 
     private void showDialog(int dialogType, double dialogValue,


### PR DESCRIPTION
This patches adds setFactory in DateTimeChooserAndroid to plumb the interface to a DateTime prompt.