### PR TITLE
Add Safe Json Java to Wolvic

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -281,6 +281,7 @@ dist_aar("content_aar") {
     "//device/vr:vr",
     "//device/vr/android:vr_android",
     "//media/base/android:media_java",
+    "//services/data_decoder/public/cpp/android:safe_json_java",
     "//services/device/public/java:nfc_java",
     "//ui/android:ui_full_java",
   ]


### PR DESCRIPTION
This patch fixes the crash issue by safe json's Java class not being included in the package.