### PR TITLE
Use vsync of Wolvic

### DIFF
--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -540,6 +540,7 @@ struct VRBrowserState {
   bool detectRuntimesOnly;
   bool presentationActive;
   bool navigationTransitionActive;
+  bool dropFame;
   VRLayerState layerState[kVRLayerMaxCount];
   VRHapticState hapticState[kVRHapticsMaxCount];
 

--- a/wolvic/browser/vr/wvr_api.cc
+++ b/wolvic/browser/vr/wvr_api.cc
@@ -108,9 +108,12 @@ bool WvrApi::SyncState(bool is_frame_submmitted,
     externalRect.height = 1.0f;
   }
 
+  browser_state_.dropFame = !is_frame_submmitted;
+  uint64_t oldDroppedFrameCount = system_state_.displayState.droppedFrameCount;
   PushState(true);
-  PullState([this]() {
-    return (system_state_.displayState.lastSubmittedFrameId == sync_frame_index_) ||
+  PullState([this, oldDroppedFrameCount]() {
+    return (system_state_.displayState.lastSubmittedFrameId == sync_frame_index_ &&
+           (!browser_state_.dropFame || system_state_.displayState.droppedFrameCount != oldDroppedFrameCount)) ||
            system_state_.displayState.suppressFrames ||
            !system_state_.displayState.isConnected;
   });


### PR DESCRIPTION
This patch fixes the issue that does not reflect the frame skip of the web page's intention by using vsync of wolvic. If the frame skip is requred, then `dropFrame` will be true, and Chromium will wait a next tick of vsync in wolvic side, and then will get a new frame's information.