### PR TITLE
Introduce skippable navigation entries

### DIFF
--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -25,6 +25,13 @@ import org.chromium.wolvic.WolvicWebContentsDelegate;
 
 @JNINamespace("wolvic")
 public class Tab {
+    // The following key and value must be set on a navigation entry extra data to let browser
+    // know that the entry must be skipped when going back/forward.
+    public static final String NAVIGATION_ENTRY_MARKED_AS_SKIPPED_KEY =
+            "NAVIGATION_ENTRY_MARKED_AS_SKIPPED_KEY";
+    public static final String NAVIGATION_ENTRY_MARKED_AS_SKIPPED_VALUE =
+            "NAVIGATION_ENTRY_MARKED_AS_SKIPPED_VALUE";
+
     private ActivityWindowAndroid mWindowAndroid;
     private ContentView mContentView;
     private NavigationController mNavigationController;
@@ -65,11 +72,15 @@ public class Tab {
     }
 
     public void goBack() {
-        mNavigationController.goBack();
+        if (mNavigationController != null) {
+          mNavigationController.goToOffset(findBackForwardNavigationOffset(/*goBack=*/true));
+        }
     }
 
     public void goForward() {
-        mNavigationController.goForward();
+        if (mNavigationController != null) {
+          mNavigationController.goToOffset(findBackForwardNavigationOffset(/*goBack=*/false));
+        }
     }
 
     public void reload() {
@@ -116,6 +127,30 @@ public class Tab {
         return ThreadUtils.runOnUiThreadBlockingNoException(() -> {
             return TabJni.get().getCurrentZoomLevel(mWebContents);
         });
+    }
+
+    private boolean isEntryMarkedAsSkipped(int entryIndex) {
+        return NAVIGATION_ENTRY_MARKED_AS_SKIPPED_VALUE.equals(
+                mNavigationController.getEntryExtraData(entryIndex, NAVIGATION_ENTRY_MARKED_AS_SKIPPED_KEY));
+    }
+
+    private int findBackForwardNavigationOffset(boolean goBack) {
+        if (mNavigationController == null) {
+            return 0;
+        }
+
+        int currentIndex = mNavigationController.getLastCommittedEntryIndex();
+        int offset = 0;
+        do {
+            offset += goBack ? -1 : 1;
+            // When the offset is out of bounds it means that we couldn't find a suitable entry
+            // to go to. Return 0 to stay at the current entry.
+            if (!mNavigationController.canGoToOffset(offset)) {
+                return 0;
+            }
+        } while (isEntryMarkedAsSkipped(currentIndex + offset));
+
+        return offset;
     }
 
     @NativeMethods

--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -32,6 +32,8 @@ public class Tab {
     public static final String NAVIGATION_ENTRY_MARKED_AS_SKIPPED_VALUE =
             "NAVIGATION_ENTRY_MARKED_AS_SKIPPED_VALUE";
 
+    private enum NavigationDirection { BACK, FORWARD };
+
     private ActivityWindowAndroid mWindowAndroid;
     private ContentView mContentView;
     private NavigationController mNavigationController;
@@ -72,15 +74,11 @@ public class Tab {
     }
 
     public void goBack() {
-        if (mNavigationController != null) {
-          mNavigationController.goToOffset(findBackForwardNavigationOffset(/*goBack=*/true));
-        }
+        mNavigationController.goToOffset(findBackForwardNavigationOffset(NavigationDirection.BACK));
     }
 
     public void goForward() {
-        if (mNavigationController != null) {
-          mNavigationController.goToOffset(findBackForwardNavigationOffset(/*goBack=*/false));
-        }
+        mNavigationController.goToOffset(findBackForwardNavigationOffset(NavigationDirection.FORWARD));
     }
 
     public void reload() {
@@ -134,15 +132,11 @@ public class Tab {
                 mNavigationController.getEntryExtraData(entryIndex, NAVIGATION_ENTRY_MARKED_AS_SKIPPED_KEY));
     }
 
-    private int findBackForwardNavigationOffset(boolean goBack) {
-        if (mNavigationController == null) {
-            return 0;
-        }
-
+    private int findBackForwardNavigationOffset(NavigationDirection direction) {
         int currentIndex = mNavigationController.getLastCommittedEntryIndex();
         int offset = 0;
         do {
-            offset += goBack ? -1 : 1;
+            offset += direction == NavigationDirection.BACK ? -1 : 1;
             // When the offset is out of bounds it means that we couldn't find a suitable entry
             // to go to. Return 0 to stay at the current entry.
             if (!mNavigationController.canGoToOffset(offset)) {


### PR DESCRIPTION
Allow browser to mark navigation entries as 'skippable' so that they are not used when performing back/forward navigation. This allows us to fix navigation issues caused by YouTube redirects to desktop app.

This change also fixes a crash which happened when rapidly clicking back/forward button multiple times by ensuring that any navigation doesn't go out of bounds.

Fixes #66 