### PR TITLE
Implement HTTP Auth prompt

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -35,6 +35,8 @@ shared_library("libcontent_native") {
     "browser/media/wolvic_media_drm_bridge_client.h",
     "browser/dialogs/color_chooser_manager.cc",
     "browser/dialogs/color_chooser_manager.h",
+    "browser/dialogs/http_auth_manager.cc",
+    "browser/dialogs/http_auth_manager.h",
     "browser/dialogs/wolvic_javascript_dialog_manager.cc",
     "browser/dialogs/wolvic_javascript_dialog_manager.h",
     "browser/dialogs/user_dialog_manager_bridge.cc",
@@ -220,6 +222,7 @@ generate_jni("jni_headers") {
   sources = [
     "java/org/chromium/wolvic/ColorChooserManager.java",
     "java/org/chromium/wolvic/DownloadManagerBridge.java",
+    "java/org/chromium/wolvic/HttpAuthManager.java",
     "java/org/chromium/wolvic/PermissionManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",
@@ -234,6 +237,7 @@ android_library("wolvic_java") {
   sources = [
     "java/org/chromium/wolvic/ColorChooserManager.java",
     "java/org/chromium/wolvic/DownloadManagerBridge.java",
+    "java/org/chromium/wolvic/HttpAuthManager.java",
     "java/org/chromium/wolvic/PermissionManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",
     "java/org/chromium/wolvic/Tab.java",

--- a/wolvic/browser/dialogs/http_auth_manager.cc
+++ b/wolvic/browser/dialogs/http_auth_manager.cc
@@ -1,0 +1,73 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/browser/dialogs/http_auth_manager.h"
+
+#include "base/android/jni_android.h"
+#include "base/android/jni_string.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/web_contents.h"
+#include "net/base/auth.h"
+#include "url/android/gurl_android.h"
+#include "wolvic/jni_headers/HttpAuthManager_jni.h"
+
+namespace wolvic {
+
+HttpAuthManager::HttpAuthManager(
+    const net::AuthChallengeInfo& auth_info,
+    content::WebContents* web_contents,
+    bool first_auth_attempt,
+    LoginAuthRequiredCallback callback)
+    : callback_(std::move(callback)) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  GURL url = auth_info.challenger.GetURL().Resolve(auth_info.path);
+  JNIEnv* env = base::android::AttachCurrentThread();
+  java_impl_ = Java_HttpAuthManager_create(
+      env, reinterpret_cast<intptr_t>(this),
+      url::GURLAndroid::FromNativeGURL(env, url), auth_info.is_proxy,
+      first_auth_attempt);
+}
+
+HttpAuthManager::~HttpAuthManager() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  CloseDialog();
+  if (java_impl_) {
+    JNIEnv* env = base::android::AttachCurrentThread();
+    Java_HttpAuthManager_destroyed(env, java_impl_);
+    java_impl_ = nullptr;
+  }
+}
+
+void HttpAuthManager::CloseDialog() {
+  if (!java_impl_)
+    return;
+
+  JNIEnv* env = base::android::AttachCurrentThread();
+  Java_HttpAuthManager_closeDialog(env, java_impl_);
+}
+
+void HttpAuthManager::Proceed(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jstring>& username,
+    const base::android::JavaParamRef<jstring>& password) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  if (callback_) {
+    std::move(callback_).Run(net::AuthCredentials(
+        base::android::ConvertJavaStringToUTF16(env, username),
+        base::android::ConvertJavaStringToUTF16(env, password)));
+  }
+
+  CloseDialog();
+}
+
+void HttpAuthManager::Cancel(JNIEnv* env) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  if (callback_)
+    std::move(callback_).Run(absl::nullopt);
+
+  CloseDialog();
+}
+
+}  // namespace wolvic

--- a/wolvic/browser/dialogs/http_auth_manager.h
+++ b/wolvic/browser/dialogs/http_auth_manager.h
@@ -1,0 +1,45 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WOLVIC_BROWSER_DIALOGS_HTTP_AUTH_MANAGER_H_
+#define WOLVIC_BROWSER_DIALOGS_HTTP_AUTH_MANAGER_H_
+
+#include "base/android/scoped_java_ref.h"
+#include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/login_delegate.h"
+
+namespace content {
+class WebContents;
+}
+
+namespace net {
+class AuthChallengeInfo;
+}
+
+namespace wolvic {
+
+// Implements support for http auth.
+class HttpAuthManager : public content::LoginDelegate {
+ public:
+  HttpAuthManager(const net::AuthChallengeInfo& auth_info,
+                      content::WebContents* web_contents,
+                      bool first_auth_attempt,
+                      LoginAuthRequiredCallback callback);
+  ~HttpAuthManager() override;
+
+  void Proceed(JNIEnv* env,
+               const base::android::JavaParamRef<jstring>& username,
+               const base::android::JavaParamRef<jstring>& password);
+  void Cancel(JNIEnv* env);
+
+ private:
+  void CloseDialog();
+
+  LoginAuthRequiredCallback callback_;
+  base::android::ScopedJavaGlobalRef<jobject> java_impl_;
+};
+
+}  // namespace wolvic
+
+#endif  // WOLVIC_BROWSER_DIALOGS_HTTP_AUTH_MANAGER_H_

--- a/wolvic/java/org/chromium/wolvic/HttpAuthManager.java
+++ b/wolvic/java/org/chromium/wolvic/HttpAuthManager.java
@@ -1,0 +1,85 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.url.GURL;
+
+/**
+ * Manages showing http auth prompt.
+ */
+@JNINamespace("wolvic")
+public final class HttpAuthManager {
+    public interface Bridge {
+        void show();
+        void close();
+    }
+
+    public interface Listener {
+        void proceed(String username, String password);
+        void cancel();
+    }
+
+    public interface Factory {
+        public Bridge create(GURL url, boolean isProxy,
+                             boolean firstAuthAttempt, Listener listener);
+    }
+
+    private static Factory sFactory;
+    private final Bridge mBridge;
+    private long mNativeHttpAuthManagerHandle;
+
+    @CalledByNative
+    public static HttpAuthManager create(long nativeHttpAuthManagerHandle, GURL url,
+                                         boolean isProxy, boolean firstAuthAttempt) {
+        return new HttpAuthManager(nativeHttpAuthManagerHandle, url, isProxy, firstAuthAttempt);
+    }
+
+    @CalledByNative
+    void destroyed() {
+        mNativeHttpAuthManagerHandle = 0;
+    }
+
+    @CalledByNative
+    private void closeDialog() {
+        if (mBridge != null) mBridge.close();
+    }
+
+    public static void setFactory(Factory factory) {
+        sFactory = factory;
+    }
+
+    private HttpAuthManager(long nativeHttpAuthManagerHandle, GURL url, boolean isProxy,
+                            boolean firstAuthAttempt) {
+        mNativeHttpAuthManagerHandle = nativeHttpAuthManagerHandle;
+
+        Listener listener = new Listener() {
+            @Override
+            public void proceed(String username, String password) {
+                if (mNativeHttpAuthManagerHandle != 0) {
+                    HttpAuthManagerJni.get().proceed(mNativeHttpAuthManagerHandle, username, password);
+                }
+            }
+
+            @Override
+            public void cancel() {
+                if (mNativeHttpAuthManagerHandle != 0) {
+                    HttpAuthManagerJni.get().cancel(mNativeHttpAuthManagerHandle);
+                }
+            }
+        };
+
+        mBridge = sFactory.create(url, isProxy, firstAuthAttempt, listener);
+        mBridge.show();
+    }
+
+    @NativeMethods
+    interface Natives {
+        void proceed(long nativeHttpAuthManager, String username, String password);
+        void cancel(long nativeHttpAuthManager);
+    }
+}

--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -15,6 +15,7 @@
 #include "content/shell/browser/shell_devtools_manager_delegate.h"
 #include "media/mojo/mojom/media_drm_storage.mojom.h"
 #include "services/network/public/mojom/network_context.mojom.h"
+#include "wolvic/browser/dialogs/http_auth_manager.h"
 #include "wolvic/browser/session_settings.h"
 #include "wolvic/wolvic_browser_context.h"
 #include "wolvic/wolvic_content_main_delegate.h"
@@ -98,6 +99,21 @@ std::unique_ptr<content::DevToolsManagerDelegate>
 WolvicContentBrowserClient::CreateDevToolsManagerDelegate() {
   return std::make_unique<content::ShellDevToolsManagerDelegate>(
       browser_context());
+}
+
+std::unique_ptr<content::LoginDelegate>
+WolvicContentBrowserClient::CreateLoginDelegate(
+    const net::AuthChallengeInfo& auth_info,
+    content::WebContents* web_contents,
+    const content::GlobalRequestID& request_id,
+    bool is_request_for_primary_main_frame,
+    const GURL& url,
+    scoped_refptr<net::HttpResponseHeaders> response_headers,
+    bool first_auth_attempt,
+    LoginAuthRequiredCallback auth_required_callback) {
+  return std::make_unique<wolvic::HttpAuthManager>(
+      auth_info, web_contents, first_auth_attempt,
+      std::move(auth_required_callback));
 }
 
 #if BUILDFLAG(ENABLE_VR)

--- a/wolvic/wolvic_content_browser_client.h
+++ b/wolvic/wolvic_content_browser_client.h
@@ -45,6 +45,15 @@ class WolvicContentBrowserClient : public ContentBrowserClient {
       bool is_integration_test) override;
   std::unique_ptr<content::DevToolsManagerDelegate>
   CreateDevToolsManagerDelegate() override;
+  std::unique_ptr<LoginDelegate> CreateLoginDelegate(
+      const net::AuthChallengeInfo& auth_info,
+      WebContents* web_contents,
+      const GlobalRequestID& request_id,
+      bool is_request_for_primary_main_frame,
+      const GURL& url,
+      scoped_refptr<net::HttpResponseHeaders> response_headers,
+      bool first_auth_attempt,
+      LoginAuthRequiredCallback auth_required_callback) override;
 #if BUILDFLAG(ENABLE_VR)
   XrIntegrationClient* GetXrIntegrationClient() override;
 #endif


### PR DESCRIPTION
This patch implements to support a HTTP Authentication's prompt that asks the user for a username and password when 401 or 407 status is received as an HTTP response.