### PR TITLE
Implement file selection

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -35,6 +35,8 @@ shared_library("libcontent_native") {
     "browser/media/wolvic_media_drm_bridge_client.h",
     "browser/dialogs/color_chooser_manager.cc",
     "browser/dialogs/color_chooser_manager.h",
+    "browser/dialogs/file_select_manager.cc",
+    "browser/dialogs/file_select_manager.h",
     "browser/dialogs/http_auth_manager.cc",
     "browser/dialogs/http_auth_manager.h",
     "browser/dialogs/wolvic_javascript_dialog_manager.cc",
@@ -222,6 +224,7 @@ generate_jni("jni_headers") {
   sources = [
     "java/org/chromium/wolvic/ColorChooserManager.java",
     "java/org/chromium/wolvic/DownloadManagerBridge.java",
+    "java/org/chromium/wolvic/FileSelectManager.java",
     "java/org/chromium/wolvic/HttpAuthManager.java",
     "java/org/chromium/wolvic/PermissionManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",
@@ -237,6 +240,7 @@ android_library("wolvic_java") {
   sources = [
     "java/org/chromium/wolvic/ColorChooserManager.java",
     "java/org/chromium/wolvic/DownloadManagerBridge.java",
+    "java/org/chromium/wolvic/FileSelectManager.java",
     "java/org/chromium/wolvic/HttpAuthManager.java",
     "java/org/chromium/wolvic/PermissionManagerBridge.java",
     "java/org/chromium/wolvic/SessionSettings.java",

--- a/wolvic/browser/dialogs/file_select_manager.cc
+++ b/wolvic/browser/dialogs/file_select_manager.cc
@@ -1,0 +1,141 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/browser/dialogs/file_select_manager.h"
+
+#include "base/android/jni_android.h"
+#include "base/android/jni_array.h"
+#include "base/android/jni_string.h"
+#include "base/strings/utf_string_conversions.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "wolvic/jni_headers/FileSelectManager_jni.h"
+
+using base::android::AttachCurrentThread;
+using base::android::ConvertJavaStringToUTF8;
+using base::android::JavaParamRef;
+using base::android::ToJavaArrayOfStrings;
+using base::android::ScopedJavaLocalRef;
+
+namespace wolvic {
+
+// static
+void FileSelectManager::RunFileChooser(
+    content::RenderFrameHost* render_frame_host,
+    scoped_refptr<content::FileSelectListener> listener,
+    const blink::mojom::FileChooserParams& params) {
+  // FileSelectManager will keep itself alive until it sends the result
+  // message.
+  scoped_refptr<FileSelectManager> file_select_manager(new FileSelectManager());
+  file_select_manager->RunSelectFile(render_frame_host, std::move(listener),
+                                     params);
+}
+
+FileSelectManager::FileSelectManager() = default;
+
+FileSelectManager::~FileSelectManager() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  // There may be pending file dialogs, we need to tell them that we've gone
+  // away so they don't try and call back to us.
+  if (java_impl_) {
+    JNIEnv* env = AttachCurrentThread();
+    Java_FileSelectManager_destroyed(env, java_impl_);
+  }
+}
+
+void FileSelectManager::OnFileSelected(
+    JNIEnv* env, const JavaParamRef<jstring>& filepath) {
+  std::string path = ConvertJavaStringToUTF8(env, filepath);
+  ConvertToFileChooserFileInfoList({base::FilePath(path)});
+}
+
+void FileSelectManager::OnMultipleFilesSelected(
+    JNIEnv* env, const JavaParamRef<jobjectArray>& filepaths) {
+  std::vector<base::FilePath> selected_files;
+  jsize length = env->GetArrayLength(filepaths);
+  for (int i = 0; i < length; ++i) {
+    ScopedJavaLocalRef<jstring> path_ref(
+        env, static_cast<jstring>(env->GetObjectArrayElement(filepaths, i)));
+    base::FilePath file_path =
+        base::FilePath(ConvertJavaStringToUTF8(env, path_ref));
+    selected_files.push_back(file_path);
+  }
+  ConvertToFileChooserFileInfoList(selected_files);
+}
+
+void FileSelectManager::OnFileSelectionCanceled(JNIEnv* env) {
+  RunSelectFileEnd();
+}
+
+void FileSelectManager::RunSelectFile(
+    content::RenderFrameHost* render_frame_host,
+    scoped_refptr<content::FileSelectListener> listener,
+    const blink::mojom::FileChooserParams& params) {
+  DCHECK(!web_contents_);
+  DCHECK(listener);
+  DCHECK(!listener_);
+  DCHECK(!java_impl_);
+
+  listener_ = std::move(listener);
+  web_contents_ = content::WebContents::FromRenderFrameHost(render_frame_host)
+                      ->GetWeakPtr();
+
+  dialog_mode_ = params.mode;
+
+  std::pair<std::vector<std::u16string>, bool> accept_types =
+      std::make_pair(params.accept_types, params.use_media_capture);
+
+  JNIEnv* env = AttachCurrentThread();
+  java_impl_ = Java_FileSelectManager_create(env, reinterpret_cast<intptr_t>(this));
+
+  ScopedJavaLocalRef<jobjectArray> accept_types_java =
+      ToJavaArrayOfStrings(env, params.accept_types);
+  bool accept_multiple_files =
+      blink::mojom::FileChooserParams::Mode::kOpenMultiple == params.mode;
+  Java_FileSelectManager_selectFile(env, java_impl_, accept_types_java,
+                                    params.use_media_capture,
+                                    accept_multiple_files);
+
+  // Because this class returns notifications to the RenderViewHost, it is
+  // difficult for callers to know how long to keep a reference to this
+  // instance. We AddRef() here to keep the instance alive after we return
+  // to the caller, until the last callback is received from the file dialog
+  // on Android.
+  AddRef();
+}
+
+void FileSelectManager::RunSelectFileEnd() {
+  if (listener_)
+    listener_->FileSelectionCanceled();
+
+  JNIEnv* env = AttachCurrentThread();
+  Java_FileSelectManager_destroyed(env, java_impl_);
+  java_impl_ = nullptr;
+  Release();
+}
+
+void FileSelectManager::ConvertToFileChooserFileInfoList(
+    const std::vector<base::FilePath>& files) {
+  if (!web_contents_) {
+    RunSelectFileEnd();
+    return;
+  }
+
+  std::vector<blink::mojom::FileChooserFileInfoPtr> selected_files;
+  for (const auto& file : files) {
+    selected_files.push_back(
+        blink::mojom::FileChooserFileInfo::NewNativeFile(
+            blink::mojom::NativeFileInfo::New(file, file.BaseName().AsUTF16Unsafe())));
+  }
+
+  listener_->FileSelected(std::move(selected_files), base::FilePath(),
+                          dialog_mode_);
+  listener_ = nullptr;
+
+  // No members should be accessed from here on.
+  RunSelectFileEnd();
+}
+
+}  // namespace wolvic

--- a/wolvic/browser/dialogs/file_select_manager.h
+++ b/wolvic/browser/dialogs/file_select_manager.h
@@ -1,0 +1,84 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WOLVIC_BROWSER_DIALOGS_FILE_SELECT_MANAGER_H_
+#define WOLVIC_BROWSER_DIALOGS_FILE_SELECT_MANAGER_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/android/scoped_java_ref.h"
+#include "base/memory/weak_ptr.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/child_process_host.h"
+#include "content/public/browser/file_select_listener.h"
+
+namespace content {
+class FileSelectListener;
+class RenderFrameHost;
+class WebContents;
+}  // namespace content
+
+namespace wolvic {
+
+// This class handles file-selection requests coming from renderer processes.
+// It implements both the initialisation and listener functions for
+// file-selection dialogs on Java.
+class FileSelectManager : public base::RefCountedThreadSafe<FileSelectManager,
+                          content::BrowserThread::DeleteOnUIThread> {
+ public:
+  FileSelectManager(const FileSelectManager&) = delete;
+  FileSelectManager& operator=(const FileSelectManager&) = delete;
+
+  // Show the file chooser dialog.
+  static void RunFileChooser(
+      content::RenderFrameHost* render_frame_host,
+      scoped_refptr<content::FileSelectListener> listener,
+      const blink::mojom::FileChooserParams& params);
+
+  void OnFileSelected(
+      JNIEnv* env, const base::android::JavaParamRef<jstring>& filepath);
+  void OnMultipleFilesSelected(
+      JNIEnv* env, const base::android::JavaParamRef<jobjectArray>& filepaths);
+  void OnFileSelectionCanceled(JNIEnv* env);
+
+ private:
+  friend class base::RefCountedThreadSafe<FileSelectManager>;
+  friend class base::DeleteHelper<FileSelectManager>;
+  friend struct content::BrowserThread::DeleteOnThread<
+      content::BrowserThread::UI>;
+
+  FileSelectManager();
+  ~FileSelectManager();
+
+  void RunSelectFile(content::RenderFrameHost* render_frame_host,
+                     scoped_refptr<content::FileSelectListener> listener,
+                     const blink::mojom::FileChooserParams& params);
+
+  // Cleans up and releases this instance. This must be called after the last
+  // callback is received from the file chooser dialog.
+  void RunSelectFileEnd();
+
+  // This method is called after the user has chosen the file(s) in the UI in
+  // order to process and filter the list before returning the final result to
+  // the caller.
+  void ConvertToFileChooserFileInfoList(
+      const std::vector<base::FilePath>& files);
+
+  // A weak pointer to the WebContents of the RenderFrameHost, for life checks.
+  base::WeakPtr<content::WebContents> web_contents_;
+
+  // |listener_| receives the result of the FileSelectManager.
+  scoped_refptr<content::FileSelectListener> listener_;
+
+  base::android::ScopedJavaGlobalRef<jobject> java_impl_;
+
+  // The mode of file dialog last shown.
+  blink::mojom::FileChooserParams::Mode dialog_mode_ =
+      blink::mojom::FileChooserParams::Mode::kOpen;
+};
+
+}  // namespace wolvic
+
+#endif  // WOLVIC_BROWSER_DIALOGS_FILE_SELECT_MANAGER_H_

--- a/wolvic/browser/wolvic_web_contents_delegate.cc
+++ b/wolvic/browser/wolvic_web_contents_delegate.cc
@@ -11,6 +11,7 @@
 #include "wolvic/jni_headers/WolvicWebContentsDelegate_jni.h"
 #include "url/android/gurl_android.h"
 #include "wolvic/browser/dialogs/color_chooser_manager.h"
+#include "wolvic/browser/dialogs/file_select_manager.h"
 #include "wolvic/browser/dialogs/wolvic_javascript_dialog_manager.h"
 
 namespace wolvic {
@@ -74,6 +75,14 @@ std::unique_ptr<content::ColorChooser> WolvicWebContentsDelegate::OpenColorChoos
     SkColor color,
     const std::vector<blink::mojom::ColorSuggestionPtr>& suggestions) {
   return std::make_unique<ColorChooserManager>(web_contents, color, suggestions);
+}
+
+void WolvicWebContentsDelegate::RunFileChooser(
+    content::RenderFrameHost* render_frame_host,
+    scoped_refptr<content::FileSelectListener> listener,
+    const blink::mojom::FileChooserParams& params) {
+  FileSelectManager::RunFileChooser(render_frame_host, std::move(listener),
+                                   params);
 }
 
 } // namespace wolvic

--- a/wolvic/browser/wolvic_web_contents_delegate.h
+++ b/wolvic/browser/wolvic_web_contents_delegate.h
@@ -38,6 +38,10 @@ class WolvicWebContentsDelegate
       SkColor color,
       const std::vector<blink::mojom::ColorSuggestionPtr>& suggestions) override;
 
+  void RunFileChooser(content::RenderFrameHost* render_frame_host,
+                      scoped_refptr<content::FileSelectListener> listener,
+                      const blink::mojom::FileChooserParams& params) override;
+
  private:
   std::unique_ptr<content::WebContents> new_contents_;
   std::unique_ptr<WolvicJavascriptDialogManager> javascript_dialog_manager_;

--- a/wolvic/java/org/chromium/wolvic/FileSelectManager.java
+++ b/wolvic/java/org/chromium/wolvic/FileSelectManager.java
@@ -1,0 +1,81 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+
+@JNINamespace("wolvic")
+public class FileSelectManager {
+    public interface Bridge {
+        void selectFile(String[] acceptMimeTypes, boolean capture, boolean allowMultiple);
+        void close();
+    }
+
+    public interface Listener {
+        void onFileSelected(String filePath);
+        void onMultipleFilesSelected(String[] filePathArray);
+        void onCanceled();
+    }
+
+    public interface Factory {
+        public Bridge create(Listener listener);
+    }
+
+    private static Factory sFactory;
+    private final Bridge mBridge;
+    private long mNativeFileSelectManagerHandle;
+
+    private FileSelectManager(long nativeFileSelectManagerHandle) {
+        Listener listener = new Listener() {
+            @Override
+            public void onFileSelected(String filePath) {
+                FileSelectManagerJni.get().onFileSelected(
+                        mNativeFileSelectManagerHandle, filePath);
+            }
+
+            @Override
+            public void onMultipleFilesSelected(String[] filePathArray) {
+                FileSelectManagerJni.get().onMultipleFilesSelected(
+                        mNativeFileSelectManagerHandle, filePathArray);
+            }
+
+            @Override
+            public void onCanceled() {
+                FileSelectManagerJni.get().onFileSelectionCanceled(mNativeFileSelectManagerHandle);
+            }
+        };
+
+        mNativeFileSelectManagerHandle = nativeFileSelectManagerHandle;
+        mBridge = sFactory.create(listener);
+    }
+
+    public static void setFactory(Factory factory) {
+        sFactory = factory;
+    }
+
+    @CalledByNative
+    public static FileSelectManager create(long nativeFileSelectManagerHandle) {
+        return new FileSelectManager(nativeFileSelectManagerHandle);
+    }
+
+    @CalledByNative
+    void selectFile(String[] acceptMimeTypes, boolean capture, boolean allowMultiple) {
+        mBridge.selectFile(acceptMimeTypes, capture, allowMultiple);
+    }
+
+    @CalledByNative
+    void destroyed() {
+        mNativeFileSelectManagerHandle = 0;
+    }
+
+    @NativeMethods
+    interface Natives {
+        void onFileSelected(long nativeFileSelectManager, String filePath);
+        void onMultipleFilesSelected(long nativeFileSelectManager, String[] filePathArray);
+        void onFileSelectionCanceled(long nativeFileSelectManager);
+    }
+}


### PR DESCRIPTION
This patch implements the file selection that uses `<input type=file>`. The selected file should be an absolute file path since the policy checking if the file can be read only allows the absolute file path.