### PR TITLE
Get rid of all testonly dependencies

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -15,7 +15,6 @@ group("empty_group") {
 }
 
 shared_library("libcontent_native") {
-  testonly = true
   sources = [
     "../content/shell/browser/shell.cc",
     "../content/shell/browser/shell.h",
@@ -33,6 +32,8 @@ shared_library("libcontent_native") {
     "browser/downloads/wolvic_download_manager_delegate.h",
     "browser/media/wolvic_media_drm_bridge_client.cc",
     "browser/media/wolvic_media_drm_bridge_client.h",
+    "browser/metrics/wolvic_enabled_state_provider.cc",
+    "browser/metrics/wolvic_enabled_state_provider.h",
     "browser/dialogs/color_chooser_manager.cc",
     "browser/dialogs/color_chooser_manager.h",
     "browser/dialogs/wolvic_javascript_dialog_manager.cc",
@@ -104,7 +105,6 @@ shared_library("libcontent_native") {
 }
 
 static_library("content_native_lib") {
-  testonly = true
   configs += [ "//build/config:precompiled_headers" ]
 
   # This is to support our dependency on //content/browser.
@@ -134,13 +134,11 @@ static_library("content_native_lib") {
     "//components/cdm/browser",
     "//components/cdm/renderer",
     "//components/custom_handlers",
-    "//components/custom_handlers:test_support",
     "//components/embedder_support:browser_util",
     "//components/embedder_support/android:web_contents_delegate",
     "//components/keyed_service/content",
     "//components/metrics",
     "//components/metrics:net",
-    "//components/metrics:test_support",
     "//components/network_hints/browser:browser",
     "//components/network_hints/renderer",
     "//components/network_session_configurator/common",
@@ -149,7 +147,6 @@ static_library("content_native_lib") {
     "//components/performance_manager",
     "//components/permissions",
     "//components/prefs",
-    "//components/services/storage/test_api",
     "//components/url_formatter",
     "//components/variations",
     "//components/variations/service",
@@ -161,14 +158,12 @@ static_library("content_native_lib") {
     "//content/common:main_frame_counter",
     "//content/public/common",
     "//content/test:content_test_mojo_bindings",
-    "//content/test:test_support",
     "//device/bluetooth",
     "//media",
     "//media/mojo:buildflags",
     "//net",
     "//net:net_resources",
     "//ppapi/buildflags",
-    "//services/device/public/cpp:test_support",
     "//services/network/public/cpp",
     "//services/test/echo:lib",
     "//services/test/echo/public/mojom",
@@ -200,7 +195,6 @@ static_library("content_native_lib") {
     deps += [
       "//components/embedder_support/android:view",
       "//content/shell/android:content_shell_jni_headers",
-      "//mojo/public/java/system:test_support",
       "//ui/android",
     ]
   }
@@ -261,7 +255,6 @@ android_library("wolvic_java") {
 }
 
 dist_aar("content_aar") {
-  testonly = true
   deps = [
     ":content_manifest",
     ":libcontent_native",
@@ -269,15 +262,11 @@ dist_aar("content_aar") {
     "//base",
     "//base:base_java",
     "//base:jni_java",
-    "//base/test:test_trace_processor",
     "//components/browser_ui/media/android:java",
     "//components/embedder_support/android:view_java",
     "//components/metrics:metrics_java",
     "//components/viz/service:service_java",
     "//content/public/android:content_full_java",
-    "//content/shell/android:content_shell_apk_java",
-    "//content/shell/android:content_shell_assets",
-    "//content/shell/android:content_shell_java",
     "//device/vr:vr",
     "//device/vr/android:vr_android",
     "//media/base/android:media_java",
@@ -287,7 +276,6 @@ dist_aar("content_aar") {
   ]
   native_libraries = [
     "$root_build_dir/libcontent_native.so",
-    "$root_build_dir/libtest_trace_processor.so",
 
     # TODO: Replace with shared library
     # "$root_build_dir/obj/device/vr/libdevice_vr.a",
@@ -354,27 +342,4 @@ dist_aar("ui_aar") {
 
   android_manifest = "UiAndroidManifest.xml"
   output = "$root_build_dir/ChromiumUi.aar"
-}
-
-dist_aar("content_shell_aar") {
-  testonly = true
-  deps = [
-    "//content/shell/android:content_shell_apk_java",
-    "//content/shell/android:content_shell_assets",
-    "//content/shell/android:content_shell_java",
-    "//content/shell/android:content_shell_java_resources",
-  ]
-  native_libraries = []
-  jar_included_patterns = [ "org/chromium/content_shell/*.class" ]
-  resource_included_patterns = [ "*content/shell/android*" ]
-  jar_excluded_patterns = [
-    "android/*.class",
-    "androidx/*.class",
-    "kotlin/*.class",
-    "org/intellij/*.class",
-    "org/jetbrains/*.class",
-  ]
-
-  android_manifest = "ContentShellAndroidManifest.xml"
-  output = "$root_build_dir/ContentShell.aar"
 }

--- a/wolvic/browser/metrics/wolvic_enabled_state_provider.cc
+++ b/wolvic/browser/metrics/wolvic_enabled_state_provider.cc
@@ -1,0 +1,17 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/browser/metrics/wolvic_enabled_state_provider.h"
+
+namespace wolvic {
+
+bool WolvicEnabledStateProvider::IsConsentGiven() const {
+  return false;
+}
+
+bool WolvicEnabledStateProvider::IsReportingEnabled() const {
+  return false;
+}
+
+}  // namespace wolvic

--- a/wolvic/browser/metrics/wolvic_enabled_state_provider.h
+++ b/wolvic/browser/metrics/wolvic_enabled_state_provider.h
@@ -1,0 +1,28 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WOLVIC_BROWSER_METRICS_WOLVIC_ENABLED_STATE_PROVIDER_H_
+#define WOLVIC_BROWSER_METRICS_WOLVIC_ENABLED_STATE_PROVIDER_H_
+
+#include "components/metrics/enabled_state_provider.h"
+
+namespace wolvic {
+
+class WolvicEnabledStateProvider : public metrics::EnabledStateProvider {
+ public:
+  WolvicEnabledStateProvider() = default;
+
+  WolvicEnabledStateProvider(const WolvicEnabledStateProvider&) = delete;
+  WolvicEnabledStateProvider& operator=(const WolvicEnabledStateProvider&) =
+      delete;
+
+  ~WolvicEnabledStateProvider() override = default;
+
+  bool IsConsentGiven() const override;
+  bool IsReportingEnabled() const override;
+};
+
+}  // namespace wolvic
+
+#endif  // WOLVIC_BROWSER_METRICS_WOLVIC_ENABLED_STATE_PROVIDER_H_

--- a/wolvic/wolvic_content_main_delegate.cc
+++ b/wolvic/wolvic_content_main_delegate.cc
@@ -24,7 +24,6 @@
 #include "components/crash/core/common/crash_key.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics/metrics_state_manager.h"
-#include "components/metrics/test/test_enabled_state_provider.h"
 #include "components/network_hints/browser/simple_network_hints_handler_impl.h"
 #include "components/prefs/json_pref_store.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -58,6 +57,7 @@
 #include "third_party/abseil-cpp/absl/types/variant.h"
 #include "ui/base/page_transition_types.h"
 #include "ui/base/resource/resource_bundle.h"
+#include "wolvic/browser/metrics/wolvic_enabled_state_provider.h"
 #include "wolvic/wolvic_browser_context.h"
 #include "wolvic/wolvic_content_browser_client.h"
 #include "wolvic/wolvic_content_client.h"
@@ -343,8 +343,7 @@ std::unique_ptr<PrefService> WolvicContentMainDelegate::CreateLocalState() {
 }
 
 void WolvicContentMainDelegate::SetUpFieldTrials() {
-  metrics::TestEnabledStateProvider enabled_state_provider(/*consent=*/false,
-                                                           /*enabled=*/false);
+  wolvic::WolvicEnabledStateProvider enabled_state_provider;
   base::FilePath path;
   base::PathService::Get(SHELL_DIR_USER_DATA, &path);
   std::unique_ptr<metrics::MetricsStateManager> metrics_state_manager =


### PR DESCRIPTION
Initially testonly flag was required by several content_shell related dependencies. Since then we reduced our dependency on content_shell heavily and this flag is no longer required. This patch removes all remaining test dependencies and gets rid of the testonly flag.