### PR TITLE
Do not let proguard remove Wolvic classes

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -326,6 +326,7 @@ dist_aar("content_aar") {
     "org/jetbrains/*.class",
   ]
   srcjar_deps = [ ":build_config_gen" ]
+  proguard_configs = [ "//wolvic/java/proguard-rules.pro" ]
 
   generate_final_jni = true
   android_manifest = "$root_gen_dir/wolvic/AndroidManifest.xml"

--- a/wolvic/java/proguard-rules.pro
+++ b/wolvic/java/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Classes with JNI call
+-keep class org.chromium.wolvic.** { *; }
+


### PR DESCRIPTION
When enabling minification in Wolvic, the Wolvic classes that are part of the Chromium tree are removed. This breaks many use cases, for example, WebXR does not work at all.

By adding a keep rule for all Wolvic classes we manage to get a fully working minified packages.