### PR TITLE
Replace a DCHECK by a null check

### DIFF
--- a/wolvic/browser/wolvic_web_contents_delegate.cc
+++ b/wolvic/browser/wolvic_web_contents_delegate.cc
@@ -39,7 +39,8 @@ void WolvicWebContentsDelegate::AddNewContents(
 
   JNIEnv* env = base::android::AttachCurrentThread();
   ScopedJavaLocalRef<jobject> java_delegate = GetJavaDelegate(env);
-  DCHECK(java_delegate.obj());
+  if (java_delegate.is_null())
+    return;
 
   // We let new_contents die on purpouse (by not assigning the
   // unique_ptr to any local variable/attribute because that way


### PR DESCRIPTION
The call to GetJavaDelegate could return jobject whose obj() is null. That's why all the delegates in chromium code have a is_null() check after the aforementioned call. We instead had a DCHECK because we thought it was not possible to get a null object there but the truth is that sometimes we do and in those cases it was causing a crash on release builds.

It's still unclear why it happens but we should avoid those crashes. When that obj() is null then we bail out and the navigation does not succeed. We haven't figured out yet which cases trigger those conditions too.