### PR TITLE
Implement media permissions support

### DIFF
--- a/wolvic/AndroidManifest.xml.jinja2
+++ b/wolvic/AndroidManifest.xml.jinja2
@@ -11,6 +11,8 @@
     android:versionName="1.0">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+
     <application
         android:zygotePreloadName="org.chromium.content_public.app.ZygotePreload" >
 

--- a/wolvic/browser/wolvic_web_contents_delegate.cc
+++ b/wolvic/browser/wolvic_web_contents_delegate.cc
@@ -6,6 +6,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/scoped_java_ref.h"
+#include "content/public/browser/browser_context.h"
 #include "content/public/browser/web_contents.h"
 #include "wolvic/browser/wolvic_contents.h"
 #include "wolvic/jni_headers/WolvicWebContentsDelegate_jni.h"
@@ -13,6 +14,7 @@
 #include "wolvic/browser/dialogs/color_chooser_manager.h"
 #include "wolvic/browser/dialogs/file_select_manager.h"
 #include "wolvic/browser/dialogs/wolvic_javascript_dialog_manager.h"
+#include "wolvic/wolvic_permission_manager.h"
 
 namespace wolvic {
 
@@ -83,6 +85,26 @@ void WolvicWebContentsDelegate::RunFileChooser(
     const blink::mojom::FileChooserParams& params) {
   FileSelectManager::RunFileChooser(render_frame_host, std::move(listener),
                                    params);
+}
+
+void WolvicWebContentsDelegate::RequestMediaAccessPermission(
+    content::WebContents* web_contents,
+    const content::MediaStreamRequest& request,
+    content::MediaResponseCallback callback) {
+  auto* permission_manager = WolvicPermissionManager::GetInstance(
+      web_contents->GetBrowserContext()->IsOffTheRecord());
+  permission_manager->RequestMediaAccessPermission(web_contents, request,
+                                                   std::move(callback));
+}
+
+bool WolvicWebContentsDelegate::CheckMediaAccessPermission(
+    content::RenderFrameHost* render_frame_host,
+    const GURL& security_origin,
+    blink::mojom::MediaStreamType type) {
+  auto* permission_manager = WolvicPermissionManager::GetInstance(
+      render_frame_host->GetBrowserContext()->IsOffTheRecord());
+  return permission_manager->CheckMediaAccessPermission(render_frame_host,
+                                                        security_origin, type);
 }
 
 } // namespace wolvic

--- a/wolvic/browser/wolvic_web_contents_delegate.h
+++ b/wolvic/browser/wolvic_web_contents_delegate.h
@@ -42,6 +42,14 @@ class WolvicWebContentsDelegate
                       scoped_refptr<content::FileSelectListener> listener,
                       const blink::mojom::FileChooserParams& params) override;
 
+  void RequestMediaAccessPermission(
+      content::WebContents* web_contents,
+      const content::MediaStreamRequest& request,
+      content::MediaResponseCallback callback) override;
+  bool CheckMediaAccessPermission(content::RenderFrameHost* render_frame_host,
+                                  const GURL& security_origin,
+                                  blink::mojom::MediaStreamType type) override;
+
  private:
   std::unique_ptr<content::WebContents> new_contents_;
   std::unique_ptr<WolvicJavascriptDialogManager> javascript_dialog_manager_;

--- a/wolvic/java/org/chromium/wolvic/PermissionManagerBridge.java
+++ b/wolvic/java/org/chromium/wolvic/PermissionManagerBridge.java
@@ -6,6 +6,7 @@ package org.chromium.wolvic;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
@@ -50,8 +51,47 @@ public class PermissionManagerBridge {
         int ALLOW = 2;
     }
 
+    @IntDef({MediaSourceType.CAMERA, MediaSourceType.SCREEN, MediaSourceType.MICROPHONE,
+            MediaSourceType.AUDIOCAPTURE, MediaSourceType.OTHER})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface MediaSourceType {
+        int CAMERA = 0;
+        int SCREEN = 1;
+        int MICROPHONE = 2;
+        int AUDIOCAPTURE = 3;
+        int OTHER = 4;
+    }
+
+    @IntDef({MediaType.VIDEO, MediaType.AUDIO})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface MediaType {
+        int VIDEO = 0;
+        int AUDIO = 1;
+    }
+
+    public static class MediaSource {
+        public final @NonNull String id;
+        public final @NonNull String name;
+        public final @MediaSourceType int source;
+        public final @MediaType int type;
+
+        public MediaSource(@NonNull String id, @Nullable String name,
+                           @MediaSourceType int source,
+                           @MediaType int type) {
+            this.id = id;
+            this.name = name;
+            this.source = source;
+            this.type = type;
+        }
+    }
+
     public interface PermissionCallback {
         void onPermissionResult(@PermissionStatus int[] results);
+    }
+
+    public interface MediaCallback {
+        void onMediaPermissionResult(boolean granted, @Nullable String videoId,
+                                     @Nullable String audioId);
     }
 
     public interface Delegate {
@@ -59,6 +99,8 @@ public class PermissionManagerBridge {
                                         boolean isOffTheRecord, PermissionCallback callback);
         void onAndroidPermissionRequest(String[] androidPermissionTypes,
                                         PermissionCallback callback);
+        void onMediaPermissionRequest(String url, MediaSource[] video, MediaSource[] audio,
+                                      MediaCallback callback);
     }
     
     private static PermissionManagerBridge sInstance;
@@ -120,6 +162,23 @@ public class PermissionManagerBridge {
         });
     }
 
+    @CalledByNative
+    public static void onMediaPermissionRequest(MediaSource[] video, MediaSource[] audio,
+                                                String url, boolean isOffTheRecord,
+                                                long inProgressRequestPtr) {
+        PermissionManagerBridge bridge = get();
+        if (bridge.mDelegate == null) {
+            return;
+        }
+        bridge.mDelegate.onMediaPermissionRequest(url, video, audio, new MediaCallback() {
+            @Override
+            public void onMediaPermissionResult(boolean granted, @Nullable String videoId,
+                                                @Nullable String audioId) {
+                PermissionManagerBridgeJni.get().onMediaPermissionResult(isOffTheRecord,
+                        inProgressRequestPtr, granted, videoId, audioId);
+            }
+        });
+    }
 
     @NativeMethods
     public interface Natives {
@@ -129,5 +188,10 @@ public class PermissionManagerBridge {
         void onAndroidPermissionResult(boolean isOffTheRecord,
                                        long inProgressRequestPtr,
                                        @PermissionStatus int[] results);
+        void onMediaPermissionResult(boolean isOffTheRecord,
+                                     long inProgressRequestPtr,
+                                     boolean granted,
+                                     @Nullable String videoId,
+                                     @Nullable String audioId);
     }
 }

--- a/wolvic/wolvic_permission_manager.cc
+++ b/wolvic/wolvic_permission_manager.cc
@@ -8,7 +8,9 @@
 #include <algorithm>
 #include <memory>
 #include <span>
+#include <string>
 
+#include "absl/types/optional.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
@@ -16,16 +18,22 @@
 #include "components/permissions/permission_util.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/media_capture_devices.h"
+#include "content/public/browser/media_stream_request.h"
 #include "content/public/browser/permission_request_description.h"
 #include "content/public/browser/permission_result.h"
 #include "content/public/browser/render_frame_host.h"
+#include "third_party/blink/public/common/mediastream/media_stream_request.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
+#include "third_party/blink/public/mojom/mediastream/media_stream.mojom.h"
 #include "url/gurl.h"
 #include "url/origin.h"
 #include "wolvic/jni_headers/PermissionManagerBridge_jni.h"
 
 namespace wolvic {
 namespace {
+
+constexpr char kMediaSourceClass[] = "org/chromium/wolvic/PermissionManagerBridge$MediaSource";
 
 // Has to be kept in sync with PermissionManagerBridge.java
 enum class WolvicPermissionType {
@@ -47,6 +55,21 @@ enum class WolvicPermissionStatus {
   kPrompt = 0,
   kDeny = 1,
   kAllow = 2,
+};
+
+// Has to be kept in sync with PermissionManagerBridge.java
+enum class MediaSourceType {
+  kCamera = 0,
+  kScreen = 1,
+  kMicrophone = 2,
+  kAudiocapture = 3,
+  kOther = 4,
+};
+
+// Has to be kept in sync with PermissionManagerBridge.java
+enum class MediaType {
+  kVideo = 0,
+  kAudio = 1,
 };
 
 WolvicPermissionType ToWolvicPermissionType(blink::PermissionType permission) {
@@ -89,6 +112,29 @@ std::string ToAndroidPermission(blink::PermissionType permission) {
       // PermissionManagerBridge.java. It's used to tell Wolvic that the given
       // permission type doesn't require any Android permissions.
       return "org.chromium.wolvic.NO_ANDROID_PERMISSION";
+  }
+}
+
+blink::PermissionType MediaStreamTypeToContentPermission(
+    blink::mojom::MediaStreamType type) {
+  using namespace blink::mojom;
+
+  switch (type) {
+    case MediaStreamType::DEVICE_AUDIO_CAPTURE:
+      return blink::PermissionType::AUDIO_CAPTURE;
+    case MediaStreamType::DEVICE_VIDEO_CAPTURE:
+      return blink::PermissionType::VIDEO_CAPTURE;
+    case MediaStreamType::GUM_TAB_AUDIO_CAPTURE:
+    case MediaStreamType::GUM_DESKTOP_AUDIO_CAPTURE:
+    case MediaStreamType::DISPLAY_AUDIO_CAPTURE:
+    case MediaStreamType::GUM_TAB_VIDEO_CAPTURE:
+    case MediaStreamType::GUM_DESKTOP_VIDEO_CAPTURE:
+    case MediaStreamType::DISPLAY_VIDEO_CAPTURE:
+    case MediaStreamType::DISPLAY_VIDEO_CAPTURE_THIS_TAB:
+    case MediaStreamType::DISPLAY_VIDEO_CAPTURE_SET:
+      return blink::PermissionType::DISPLAY_CAPTURE;
+    default:
+      NOTREACHED_NORETURN();
   }
 }
 
@@ -135,6 +181,89 @@ std::vector<content::PermissionStatus> FromJavaWolvicPermissionStatuses(
   return result;
 }
 
+MediaSourceType ToWolvicMediaSourceType(blink::mojom::MediaStreamType type) {
+  using namespace blink::mojom;
+
+  switch (type) {
+    case MediaStreamType::DEVICE_AUDIO_CAPTURE:
+      return MediaSourceType::kMicrophone;
+    case MediaStreamType::DEVICE_VIDEO_CAPTURE:
+      return MediaSourceType::kCamera;
+    case MediaStreamType::GUM_TAB_AUDIO_CAPTURE:
+    case MediaStreamType::GUM_DESKTOP_AUDIO_CAPTURE:
+    case MediaStreamType::DISPLAY_AUDIO_CAPTURE:
+      return MediaSourceType::kAudiocapture;
+    case MediaStreamType::GUM_TAB_VIDEO_CAPTURE:
+    case MediaStreamType::GUM_DESKTOP_VIDEO_CAPTURE:
+    case MediaStreamType::DISPLAY_VIDEO_CAPTURE:
+    case MediaStreamType::DISPLAY_VIDEO_CAPTURE_THIS_TAB:
+    case MediaStreamType::DISPLAY_VIDEO_CAPTURE_SET:
+      return MediaSourceType::kScreen;
+    default:
+      return MediaSourceType::kOther;
+  }
+}
+
+base::android::ScopedJavaLocalRef<jobject> CreateJavaMediaSource(
+    JNIEnv* env,
+    const std::string& id,
+    const std::string& name,
+    MediaSourceType source,
+    MediaType type) {
+  jclass cls = env->FindClass(kMediaSourceClass);
+  jmethodID constructor = env->GetMethodID(
+      cls, "<init>", "(Ljava/lang/String;Ljava/lang/String;II)V");
+  jobject media_source = env->NewObject(
+      cls, constructor, base::android::ConvertUTF8ToJavaString(env, id).obj(),
+      base::android::ConvertUTF8ToJavaString(env, name).obj(),
+      static_cast<jint>(source), static_cast<jint>(type));
+  return base::android::ScopedJavaLocalRef<jobject>(env, media_source);
+}
+
+void ToJavaMediaSources(
+    JNIEnv* env,
+    const content::MediaStreamRequest& request,
+    base::android::ScopedJavaLocalRef<jobjectArray>* video,
+    base::android::ScopedJavaLocalRef<jobjectArray>* audio) {
+  auto video_source = CreateJavaMediaSource(
+      env, request.requested_video_device_id, "",
+      ToWolvicMediaSourceType(request.video_type), MediaType::kVideo);
+  auto audio_source = CreateJavaMediaSource(
+      env, request.requested_audio_device_id, "",
+      ToWolvicMediaSourceType(request.audio_type), MediaType::kAudio);
+
+  std::vector<base::android::ScopedJavaLocalRef<jobject>> video_sources{
+      video_source};
+  std::vector<base::android::ScopedJavaLocalRef<jobject>> audio_sources{
+      audio_source};
+
+  auto media_source_class = base::android::GetClass(env, kMediaSourceClass);
+  *video = base::android::ToTypedJavaArrayOfObjects(env, video_sources,
+                                                    media_source_class);
+  *audio = base::android::ToTypedJavaArrayOfObjects(env, audio_sources,
+                                                    media_source_class);
+}
+
+// this method is copied from
+// android_webview/browser/permission/media_access_permission_request.cc
+// Return the device specified by |device_id| if exists, otherwise the first
+// available device is returned.
+const blink::MediaStreamDevice* GetDeviceByIdOrFirstAvailable(
+    const blink::MediaStreamDevices& devices,
+    const std::string& device_id) {
+  if (devices.empty())
+    return nullptr;
+
+  if (!device_id.empty()) {
+    for (const auto& device : devices) {
+      if (device.id == device_id)
+        return &device;
+    }
+  }
+
+  return &devices[0];
+}
+
 wolvic::WolvicPermissionManager* g_instance = nullptr;
 wolvic::WolvicPermissionManager* g_off_the_record_instance = nullptr;
 
@@ -168,10 +297,14 @@ std::vector<content::PermissionStatus> CombineStatuses(
 
 InProgressRequest::InProgressRequest(
     const content::PermissionRequestDescription& description,
-    base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
-        callback)
-    : description(description) {
-  callbacks.emplace_back(std::move(callback));
+    absl::optional<PermissionRequestCallback> callback,
+    absl::optional<content::MediaStreamRequest> media_request,
+    absl::optional<content::MediaResponseCallback> media_callback)
+    : description(description),
+      media_request(media_request),
+      media_callback(std::move(media_callback)) {
+  if (callback)
+    callbacks.emplace_back(std::move(callback.value()));
 }
 
 InProgressRequest::~InProgressRequest() = default;
@@ -190,11 +323,16 @@ WolvicPermissionManager::WolvicPermissionManager(
 
 WolvicPermissionManager::~WolvicPermissionManager() = default;
 
+WolvicPermissionManager* WolvicPermissionManager::GetInstance(
+    bool is_off_the_record) {
+  return is_off_the_record ? GetOffTheRecordPermissionManager()
+                           : GetPermissionManager();
+}
+
 void WolvicPermissionManager::RequestPermissions(
     content::RenderFrameHost* render_frame_host,
     const content::PermissionRequestDescription& request_description,
-    base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
-        callback) {
+    PermissionRequestCallback callback) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
   if (render_frame_host->IsNestedWithinFencedFrame()) {
@@ -227,8 +365,7 @@ void WolvicPermissionManager::ResetPermission(blink::PermissionType permission,
 void WolvicPermissionManager::RequestPermissionsFromCurrentDocument(
     content::RenderFrameHost* render_frame_host,
     const content::PermissionRequestDescription& request_description,
-    base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
-        callback) {
+    PermissionRequestCallback callback) {
   RequestPermissions(render_frame_host, request_description,
                      std::move(callback));
 }
@@ -304,6 +441,39 @@ WolvicPermissionManager::SubscribePermissionStatusChange(
 void WolvicPermissionManager::UnsubscribePermissionStatusChange(
     SubscriptionId subscription_id) {}
 
+void WolvicPermissionManager::RequestMediaAccessPermission(
+    content::WebContents* web_contents,
+    const content::MediaStreamRequest& request,
+    content::MediaResponseCallback callback) {
+  std::vector<blink::PermissionType> permissions;
+  if (request.audio_type != blink::mojom::MediaStreamType::NO_SERVICE) {
+    permissions.push_back(
+        MediaStreamTypeToContentPermission(request.audio_type));
+  }
+  if (request.video_type != blink::mojom::MediaStreamType::NO_SERVICE) {
+    permissions.push_back(
+        MediaStreamTypeToContentPermission(request.video_type));
+  }
+
+  content::PermissionRequestDescription description(
+      permissions, /*user_gesture=*/false, request.security_origin);
+  JNIEnv* env = base::android::AttachCurrentThread();
+  in_progress_requests_.emplace_back(std::make_unique<InProgressRequest>(
+      description, /*callback=*/absl::nullopt, request, std::move(callback)));
+  RequestContentPermissions(env, in_progress_requests_.back().get());
+}
+
+bool WolvicPermissionManager::CheckMediaAccessPermission(
+    content::RenderFrameHost* render_frame_host,
+    const GURL& security_origin,
+    blink::mojom::MediaStreamType type) {
+  auto it = allowed_media_permissions_cache_.find(security_origin);
+  if (it == allowed_media_permissions_cache_.end())
+    return false;
+
+  return it->second.find(type) != it->second.end();
+}
+
 void WolvicPermissionManager::OnContentPermissionResult(
     JNIEnv* env,
     InProgressRequest* in_progress_request,
@@ -316,6 +486,91 @@ void WolvicPermissionManager::OnAndroidPermissionResult(
     InProgressRequest* in_progress_request,
     const std::vector<content::PermissionStatus>& result) {
   in_progress_request->android_results = result;
+
+  // If this was part of media request, proceed with requesting media permissions.
+  if (in_progress_request->media_callback) {
+    OnMediaContentPermissionResult(
+        in_progress_request,
+        CombineStatuses(in_progress_request->content_results.value(),
+                        in_progress_request->android_results.value()));
+    return;
+  }
+
+  // Otherwise, complete the request.
+  CompleteRequest(in_progress_request);
+}
+
+void WolvicPermissionManager::OnMediaContentPermissionResult(
+    InProgressRequest* in_progress_request,
+    const std::vector<content::PermissionStatus>& result) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  base::android::ScopedJavaLocalRef<jobjectArray> video_sources;
+  base::android::ScopedJavaLocalRef<jobjectArray> audio_sources;
+  ToJavaMediaSources(env, in_progress_request->media_request.value(),
+                     &video_sources, &audio_sources);
+  auto url = base::android::ConvertUTF8ToJavaString(
+      env, in_progress_request->media_request.value().security_origin.spec());
+  Java_PermissionManagerBridge_onMediaPermissionRequest(
+      env, video_sources, audio_sources, url,
+      browser_context_->IsOffTheRecord(),
+      reinterpret_cast<jlong>(in_progress_request));
+}
+
+void WolvicPermissionManager::OnMediaPermissionResult(
+    InProgressRequest* in_progress_request,
+    bool granted,
+    const absl::optional<std::string>& video_id,
+    const absl::optional<std::string>& audio_id) {
+  blink::mojom::StreamDevicesSet stream_devices_set;
+  if (!granted) {
+    std::move(in_progress_request->media_callback.value()).Run(
+        stream_devices_set,
+        blink::mojom::MediaStreamRequestResult::PERMISSION_DENIED,
+        std::unique_ptr<content::MediaStreamUI>());
+    return;
+  }
+
+  stream_devices_set.stream_devices.emplace_back(blink::mojom::StreamDevices::New());
+  blink::mojom::StreamDevices& devices = *stream_devices_set.stream_devices.back();
+
+  if (video_id) {
+    const blink::MediaStreamDevice* device = GetDeviceByIdOrFirstAvailable(
+        content::MediaCaptureDevices::GetInstance()->GetVideoCaptureDevices(),
+        *video_id);
+    if (device)
+      devices.video_device = *device;
+  }
+
+  if (audio_id) {
+    const blink::MediaStreamDevice* device = GetDeviceByIdOrFirstAvailable(
+        content::MediaCaptureDevices::GetInstance()->GetAudioCaptureDevices(),
+        *audio_id);
+    if (device)
+      devices.audio_device = *device;
+  }
+
+  auto result = blink::mojom::MediaStreamRequestResult::NO_HARDWARE;
+
+  if (devices.video_device.has_value()) {
+    result = blink::mojom::MediaStreamRequestResult::OK;
+    allowed_media_permissions_cache_[in_progress_request->media_request
+                                         ->security_origin]
+        .insert(in_progress_request->media_request->video_type);
+  }
+
+  if (devices.audio_device.has_value()) {
+    result = blink::mojom::MediaStreamRequestResult::OK;
+    allowed_media_permissions_cache_[in_progress_request->media_request
+                                         ->security_origin]
+        .insert(in_progress_request->media_request->audio_type);
+  }
+
+  if (result == blink::mojom::MediaStreamRequestResult::NO_HARDWARE)
+    stream_devices_set.stream_devices.clear();
+
+  std::move(in_progress_request->media_callback.value())
+      .Run(stream_devices_set, result,
+           std::unique_ptr<content::MediaStreamUI>());
   CompleteRequest(in_progress_request);
 }
 
@@ -396,9 +651,8 @@ static void JNI_PermissionManagerBridge_OnContentPermissionResult(
   base::android::JavaIntArrayToIntVector(env, results,
                                          &java_permission_results);
 
-  auto* permission_manager = is_off_the_record
-                                 ? GetOffTheRecordPermissionManager()
-                                 : GetPermissionManager();
+  auto* permission_manager =
+      WolvicPermissionManager::GetInstance(is_off_the_record);
   permission_manager->OnContentPermissionResult(
       env, in_progress_request,
       FromJavaWolvicPermissionStatuses(java_permission_results));
@@ -418,12 +672,35 @@ static void JNI_PermissionManagerBridge_OnAndroidPermissionResult(
   base::android::JavaIntArrayToIntVector(env, results,
                                          &java_permission_results);
 
-  auto* permission_manager = is_off_the_record
-                                 ? GetOffTheRecordPermissionManager()
-                                 : GetPermissionManager();
+  auto* permission_manager =
+      WolvicPermissionManager::GetInstance(is_off_the_record);
   permission_manager->OnAndroidPermissionResult(
       in_progress_request,
       FromJavaWolvicPermissionStatuses(java_permission_results));
+}
+
+static void JNI_PermissionManagerBridge_OnMediaPermissionResult(
+    JNIEnv* env,
+    jboolean is_off_the_record,
+    jlong in_progress_request_ptr,
+    jboolean granted,
+    const base::android::JavaParamRef<jstring>& java_video_id,
+    const base::android::JavaParamRef<jstring>& java_audio_id) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  auto* in_progress_request =
+      reinterpret_cast<InProgressRequest*>(in_progress_request_ptr);
+  auto* permission_manager =
+      WolvicPermissionManager::GetInstance(is_off_the_record);
+  absl::optional<std::string> video_id;
+  absl::optional<std::string> audio_id;
+  if (java_video_id)
+    video_id = base::android::ConvertJavaStringToUTF8(java_video_id);
+  if (java_audio_id)
+    audio_id = base::android::ConvertJavaStringToUTF8(java_audio_id);
+
+  permission_manager->OnMediaPermissionResult(
+      in_progress_request, granted, video_id, audio_id);
 }
 
 }  // namespace wolvic

--- a/wolvic/wolvic_permission_manager.h
+++ b/wolvic/wolvic_permission_manager.h
@@ -5,27 +5,36 @@
 #ifndef WOLVIC_WOLVIC_PERMISSION_MANAGER_H_
 #define WOLVIC_WOLVIC_PERMISSION_MANAGER_H_
 
+#include "absl/types/optional.h"
 #include "content/public/browser/browser_context.h"
+#include "content/public/browser/media_stream_request.h"
 #include "content/public/browser/permission_controller_delegate.h"
 #include "content/public/browser/permission_request_description.h"
 #include "content/public/browser/permission_result.h"
 
 namespace wolvic {
 
+using PermissionRequestCallback =
+    base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>;
+
 // Holds callbacks for in-progress permission requests.
 struct InProgressRequest {
   explicit InProgressRequest(
       const content::PermissionRequestDescription& description,
-      base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
-          callback);
+      absl::optional<PermissionRequestCallback> callback = absl::nullopt,
+      absl::optional<content::MediaStreamRequest> media_request = absl::nullopt,
+      absl::optional<content::MediaResponseCallback> media_callback =
+          absl::nullopt);
 
   ~InProgressRequest();
 
   content::PermissionRequestDescription description;
-  std::vector<base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>>
-      callbacks;
+  std::vector<PermissionRequestCallback> callbacks;
   absl::optional<std::vector<content::PermissionStatus>> content_results;
   absl::optional<std::vector<content::PermissionStatus>> android_results;
+
+  absl::optional<content::MediaStreamRequest> media_request;
+  absl::optional<content::MediaResponseCallback> media_callback;
 };
 
 class WolvicPermissionManager : public content::PermissionControllerDelegate {
@@ -33,20 +42,20 @@ class WolvicPermissionManager : public content::PermissionControllerDelegate {
   explicit WolvicPermissionManager(content::BrowserContext* browser_context);
   ~WolvicPermissionManager() override;
 
+  static WolvicPermissionManager* GetInstance(bool is_off_the_record);
+
   // PermissionControllerDelegate overrides:
   void RequestPermissions(
       content::RenderFrameHost* render_frame_host,
       const content::PermissionRequestDescription& request_description,
-      base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
-          callback) override;
+      PermissionRequestCallback callback) override;
   void ResetPermission(blink::PermissionType permission,
                        const GURL& requesting_origin,
                        const GURL& embedding_origin) override;
   void RequestPermissionsFromCurrentDocument(
       content::RenderFrameHost* render_frame_host,
       const content::PermissionRequestDescription& request_description,
-      base::OnceCallback<void(const std::vector<content::PermissionStatus>&)>
-          callback) override;
+      PermissionRequestCallback callback) override;
   blink::mojom::PermissionStatus GetPermissionStatus(
       blink::PermissionType permission,
       const GURL& requesting_origin,
@@ -76,6 +85,15 @@ class WolvicPermissionManager : public content::PermissionControllerDelegate {
   void UnsubscribePermissionStatusChange(
       SubscriptionId subscription_id) override;
 
+  // Wolvic specific methods.
+  void RequestMediaAccessPermission(content::WebContents* web_contents,
+                                    const content::MediaStreamRequest& request,
+                                    content::MediaResponseCallback callback);
+  bool CheckMediaAccessPermission(content::RenderFrameHost* render_frame_host,
+                                  const GURL& security_origin,
+                                  blink::mojom::MediaStreamType type);
+
+  // Callbacks from Java.
   void OnContentPermissionResult(
       JNIEnv* env,
       InProgressRequest* in_progress_request,
@@ -83,6 +101,15 @@ class WolvicPermissionManager : public content::PermissionControllerDelegate {
   void OnAndroidPermissionResult(
       InProgressRequest* in_progress_request,
       const std::vector<content::PermissionStatus>& result);
+  // Intermediate callback which is called when content and android permissions
+  // have been granted but media permission is yet to be requested.
+  void OnMediaContentPermissionResult(
+      InProgressRequest* in_progress_request,
+      const std::vector<content::PermissionStatus>& result);
+  void OnMediaPermissionResult(InProgressRequest* in_progress_request,
+                               bool granted,
+                               const absl::optional<std::string>& video_id,
+                               const absl::optional<std::string>& audio_id);
 
  private:
   void CompleteRequest(InProgressRequest* in_progress_request);
@@ -97,6 +124,12 @@ class WolvicPermissionManager : public content::PermissionControllerDelegate {
       const content::PermissionRequestDescription& description);
 
   std::vector<std::unique_ptr<InProgressRequest>> in_progress_requests_;
+  // We cache allowed media permissions for each origin to avoid asking the user
+  // whenever |CheckMediaAccessPermission()| is called.
+  base::flat_map<GURL, base::flat_set<blink::mojom::MediaStreamType>>
+      allowed_media_permissions_cache_;
+
+  base::WeakPtrFactory<WolvicPermissionManager> weak_ptr_factory_{this};
 };
 
 }  // namespace wolvic


### PR DESCRIPTION
Extend functionality of WolvicPermissionManager to also support media permissions such as microphone and camera access. Media permissions are requested differently from other content permissions, the entry point for them is the WebContentsDelegate implementation. In this solution, we forward such calls from WolvicWebContentsDelegate to WolvicPermissionManager. The permissions manager first requests any required content and android permissions and only then requests media permissions via the PermissionManagerBridge class.