### PR TITLE
Use raw_ptr<> template instead of raw pointers

### DIFF
--- a/wolvic/browser/autocomplete/wolvic_autofill_client.h
+++ b/wolvic/browser/autocomplete/wolvic_autofill_client.h
@@ -144,7 +144,7 @@ class WolvicAutofillClient : public autofill::ContentAutofillClient {
 
   autofill::FormInteractionsFlowId flow_id_{};
   base::Time flow_id_date_;
-  content::WebContents* web_contents_;
+  raw_ptr<content::WebContents> web_contents_;
   std::vector<autofill::Suggestion> suggestions_;
   autofill::AutofillSuggestionTriggerSource trigger_source_{
       autofill::AutofillSuggestionTriggerSource::kUnspecified};

--- a/wolvic/browser/autocomplete/wolvic_signin_client.h
+++ b/wolvic/browser/autocomplete/wolvic_signin_client.h
@@ -68,7 +68,7 @@ class WolvicSigninClient : public SigninClient {
       const base::FilePath& profile_path);
   void OnCloseBrowsersAborted(const base::FilePath& profile_path);
 
-  content::WolvicBrowserContext* context_;
+  raw_ptr<content::WolvicBrowserContext> context_;
 
   // Stored callback from PreSignOut();
   base::OnceCallback<void(SignoutDecision)> on_signout_decision_reached_;


### PR DESCRIPTION
The use of raw pointers is not recommended and there are compilation flags that generate errors in debug builds.