### PR TITLE
Fix DCHECK crashes by Password Manager impl

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -31,6 +31,8 @@ shared_library("libcontent_native") {
     "../content/shell/common/shell_switches.h",
     "browser/autocomplete/wolvic_autofill_client.cc",
     "browser/autocomplete/wolvic_autofill_client.h",
+    "browser/autocomplete/wolvic_image_decoder.cc",
+    "browser/autocomplete/wolvic_image_decoder.h",
     "browser/autocomplete/wolvic_password_form_util.cc",
     "browser/autocomplete/wolvic_password_form_util.h",
     "browser/autocomplete/wolvic_password_manager_client.cc",

--- a/wolvic/browser/autocomplete/wolvic_image_decoder.cc
+++ b/wolvic/browser/autocomplete/wolvic_image_decoder.cc
@@ -1,0 +1,138 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/browser/autocomplete/wolvic_image_decoder.h"
+
+#include <vector>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/ranges/algorithm.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/task/single_thread_task_runner.h"
+#include "ipc/ipc_channel.h"
+#include "services/data_decoder/public/cpp/data_decoder.h"
+#include "services/data_decoder/public/cpp/decode_image.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/image/image.h"
+
+// Referred to image_decoder_impl.cc & image_decoder.cc in //chrome
+namespace wolvic {
+
+namespace {
+
+const int64_t kMaxImageSizeInBytes =
+    static_cast<int64_t>(IPC::Channel::kMaximumMessageSize);
+
+void RunDecodeCallbackOnTaskRunner(
+    data_decoder::DecodeImageCallback callback,
+    scoped_refptr<base::SequencedTaskRunner> task_runner,
+    const SkBitmap& image) {
+  task_runner->PostTask(FROM_HERE, base::BindOnce(std::move(callback), image));
+}
+
+// Note that this is always called on the thread which initiated the
+// corresponding data_decoder::DecodeImage request.
+void OnDecodeImageDone(
+    base::OnceCallback<void()> fail_callback,
+    base::OnceCallback<void(const SkBitmap&)> success_callback,
+    const SkBitmap& image) {
+  if (!image.isNull() && !image.empty())
+    std::move(success_callback).Run(image);
+  else
+    std::move(fail_callback).Run();
+}
+
+}  // namespace
+
+// A request for decoding an image.
+class WolvicImageDecoder::DecodeImageRequest {
+ public:
+  DecodeImageRequest(WolvicImageDecoder* decoder,
+                     const std::string& image_data,
+                     data_decoder::DataDecoder* data_decoder,
+                     const gfx::Size& desired_image_frame_size,
+                     image_fetcher::ImageDecodedCallback callback)
+      : task_runner_(base::SingleThreadTaskRunner::GetCurrentDefault()),
+        data_decoder_(data_decoder),
+        callback_(std::move(callback)) {
+    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+    base::span<const uint8_t> image_data_span(
+        base::as_bytes(base::make_span(image_data)));
+
+  auto decode_callback =
+      base::BindOnce(&OnDecodeImageDone,
+                     base::BindOnce(&DecodeImageRequest::OnDecodeImageFailed,
+                                    base::Unretained(this)),
+                     base::BindOnce(&DecodeImageRequest::OnDecodeImageSucceeded,
+                                    base::Unretained(this)));
+
+    data_decoder::DecodeImage(
+        data_decoder, image_data_span,
+        data_decoder::mojom::ImageCodec::kDefault, /*shrink_to_fit=*/false,
+        kMaxImageSizeInBytes, desired_image_frame_size,
+        base::BindOnce(&RunDecodeCallbackOnTaskRunner, std::move(decode_callback),
+                      std::move(task_runner_)));
+  }
+
+  DecodeImageRequest(const DecodeImageRequest&) = delete;
+  DecodeImageRequest& operator=(const DecodeImageRequest&) = delete;
+
+  ~DecodeImageRequest() = default;
+
+ private:
+  SEQUENCE_CHECKER(sequence_checker_);
+
+  // Runs the callback and remove the request from the internal request queue.
+  void RunCallbackAndRemoveRequest(const gfx::Image& image) {
+    std::move(callback_).Run(image);
+
+    // This must be the last line in the method body.
+    decoder_->RemoveDecodeImageRequest(this);
+  }
+
+  void OnDecodeImageSucceeded(const SkBitmap& decoded_image) {
+    DCHECK(task_runner_->RunsTasksInCurrentSequence());
+    gfx::Image image(gfx::Image::CreateFrom1xBitmap(decoded_image));
+    RunCallbackAndRemoveRequest(image);
+  }
+
+  void OnDecodeImageFailed() {
+    DCHECK(task_runner_->RunsTasksInCurrentSequence());
+    RunCallbackAndRemoveRequest(gfx::Image());
+  }
+
+  const scoped_refptr<base::SequencedTaskRunner> task_runner_;
+
+  raw_ptr<WolvicImageDecoder> decoder_;
+  raw_ptr<data_decoder::DataDecoder> data_decoder_;
+  // The callback to call after the request completed.
+  image_fetcher::ImageDecodedCallback callback_;
+};
+
+WolvicImageDecoder::WolvicImageDecoder() = default;
+
+WolvicImageDecoder::~WolvicImageDecoder() = default;
+
+void WolvicImageDecoder::DecodeImage(
+    const std::string& image_data,
+    const gfx::Size& desired_image_frame_size,
+    data_decoder::DataDecoder* data_decoder,
+    image_fetcher::ImageDecodedCallback callback) {
+  auto decode_image_request = std::make_unique<DecodeImageRequest>(
+      this, image_data, data_decoder, desired_image_frame_size, std::move(callback));
+
+  decode_image_requests_.push_back(std::move(decode_image_request));
+}
+
+void WolvicImageDecoder::RemoveDecodeImageRequest(DecodeImageRequest* request) {
+  // Remove the finished request from the request queue.
+  auto request_it =
+      base::ranges::find(decode_image_requests_, request,
+                         &std::unique_ptr<DecodeImageRequest>::get);
+  DCHECK(request_it != decode_image_requests_.end());
+  decode_image_requests_.erase(request_it);
+}
+
+}  // namespace wolvic

--- a/wolvic/browser/autocomplete/wolvic_image_decoder.h
+++ b/wolvic/browser/autocomplete/wolvic_image_decoder.h
@@ -1,0 +1,46 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WOLVIC_BROWSER_AUTOCOMPLETE_WOLVIC_IMAGE_DECODER_H_
+#define WOLVIC_BROWSER_AUTOCOMPLETE_WOLVIC_IMAGE_DECODER_H_
+
+#include <string>
+
+#include "base/functional/bind.h"
+#include "components/image_fetcher/core/image_decoder.h"
+
+namespace gfx {
+class Size;
+}  // namespace gfx
+
+namespace wolvic {
+
+// image_fetcher::ImageDecoder implementation.
+class WolvicImageDecoder : public image_fetcher::ImageDecoder {
+ public:
+  WolvicImageDecoder();
+
+  WolvicImageDecoder(const WolvicImageDecoder&) = delete;
+  WolvicImageDecoder& operator=(const WolvicImageDecoder&) = delete;
+
+  ~WolvicImageDecoder() override;
+
+  void DecodeImage(const std::string& image_data,
+                   const gfx::Size& desired_image_frame_size,
+                   data_decoder::DataDecoder* data_decoder,
+                   image_fetcher::ImageDecodedCallback callback) override;
+
+ private:
+  class DecodeImageRequest;
+
+  // Removes the passed image decode |request| from the internal request queue.
+  void RemoveDecodeImageRequest(DecodeImageRequest* request);
+
+  // All active image decoding requests.
+  std::vector<std::unique_ptr<DecodeImageRequest>> decode_image_requests_;
+};
+
+}  // namespace wolvic
+
+#endif  // WOLVIC_BROWSER_AUTOCOMPLETE_WOLVIC_IMAGE_DECODER_H_

--- a/wolvic/browser/autocomplete/wolvic_password_form_util.cc
+++ b/wolvic/browser/autocomplete/wolvic_password_form_util.cc
@@ -9,6 +9,7 @@
 #include "components/password_manager/core/browser/password_form.h"
 #include "components/password_manager/core/browser/password_manager_util.h"
 #include "wolvic/jni_headers/PasswordForm_jni.h"
+#include "url/origin.h"
 
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertJavaStringToUTF16;
@@ -54,15 +55,29 @@ GetPasswordFormFromJavaObject(
       Java_PasswordForm_getPassword(env, j_password_form));
   form->url = GURL(ConvertJavaStringToUTF8(
       Java_PasswordForm_getOrigin(env, j_password_form)));
-  form->action = GURL(ConvertJavaStringToUTF8(
-      Java_PasswordForm_getFormActionOrigin(env, j_password_form)));
-  form->signon_realm = ConvertJavaStringToUTF8(
-      Java_PasswordForm_getHttpRealm(env, j_password_form));
-  if (form->signon_realm.empty()) {
+
+  ScopedJavaLocalRef<jstring> jaction =
+      Java_PasswordForm_getFormActionOrigin(env, j_password_form);
+  if (jaction.obj() && env->GetStringLength(jaction.obj()) > 0) {
+    form->action = GURL(ConvertJavaStringToUTF8(env, jaction));
+  }
+
+  ScopedJavaLocalRef<jstring> jsignon_realm =
+      Java_PasswordForm_getHttpRealm(env, j_password_form);
+  if (jsignon_realm.obj() && env->GetStringLength(jsignon_realm.obj()) > 0) {
+    form->signon_realm = ConvertJavaStringToUTF8(env, jsignon_realm);
+  } else {
     form->signon_realm = password_manager::GetSignonRealm(form->url);
   }
-  form->keychain_identifier = ConvertJavaStringToUTF8(
-      Java_PasswordForm_getGuid(env, j_password_form));
+
+  ScopedJavaLocalRef<jstring> jguid =
+      Java_PasswordForm_getGuid(env, j_password_form);
+  if (jguid.obj() && env->GetStringLength(jguid.obj()) > 0) {
+    form->keychain_identifier = ConvertJavaStringToUTF8(env, jguid);
+  }
+
+  // We always use the profile store.
+  form->in_store = password_manager::PasswordForm::Store::kProfileStore;
   return form;
 }
 

--- a/wolvic/browser/autocomplete/wolvic_password_manager_client.cc
+++ b/wolvic/browser/autocomplete/wolvic_password_manager_client.cc
@@ -107,7 +107,9 @@ void WolvicPasswordManagerClient::OnDismissed(JNIEnv* env) {
 
 void WolvicPasswordManagerClient::HandleSavePassword(
     std::unique_ptr<password_manager::PasswordFormManagerForUI> form_to_save,
-    const password_manager::PasswordForm& saved_form) {
+  password_manager::PasswordForm& saved_form) {
+  // Avoid DCHECK when adding the new ID/PW via PasswordFormManagerForUI::Update
+  saved_form.federation_origin = url::Origin::Create(GURL(saved_form.url));
   form_to_save->Update(saved_form);
   form_to_save->Save();
 }

--- a/wolvic/browser/autocomplete/wolvic_password_manager_client.h
+++ b/wolvic/browser/autocomplete/wolvic_password_manager_client.h
@@ -157,7 +157,7 @@ class WolvicPasswordManagerClient
 
   void HandleSavePassword(
       std::unique_ptr<password_manager::PasswordFormManagerForUI> form_to_save,
-      const password_manager::PasswordForm& saved_form);
+      password_manager::PasswordForm& saved_form);
 
   // content::WebContentsObserver overrides.
   void PrimaryPageChanged(content::Page& page) override;
@@ -178,7 +178,7 @@ class WolvicPasswordManagerClient
   const password_manager::SyncCredentialsFilter credentials_filter_;
 
   // A callback to be invoked when user accept to save the password.
-  base::OnceCallback<void(const password_manager::PasswordForm& saved_form)>
+  base::OnceCallback<void(password_manager::PasswordForm& saved_form)>
       save_password_callback_;
 
   // A callback to be invoked when user selects a credential.

--- a/wolvic/browser/autocomplete/wolvic_password_store_backend.cc
+++ b/wolvic/browser/autocomplete/wolvic_password_store_backend.cc
@@ -239,7 +239,6 @@ void WolvicPasswordStoreBackend::FillMatchingLoginsAsync(
 void WolvicPasswordStoreBackend::GetGroupedMatchingLoginsAsync(
     const password_manager::PasswordFormDigest& form_digest,
     password_manager::LoginsOrErrorReply callback) {
-  DCHECK(affiliated_match_helper_);
   GetLoginsWithAffiliationsRequestHandler(
       form_digest, this, affiliated_match_helper_.get(), std::move(callback));
 }

--- a/wolvic/wolvic_browser_context.cc
+++ b/wolvic/wolvic_browser_context.cc
@@ -53,6 +53,7 @@
 #include "content/test/mock_background_sync_controller.h"
 #include "content/test/mock_reduce_accept_language_controller_delegate.h"
 #include "third_party/blink/public/common/origin_trials/trial_token_validator.h"
+#include "wolvic/browser/autocomplete/wolvic_image_decoder.h"
 #include "wolvic/browser/autocomplete/wolvic_password_store_backend.h"
 #include "wolvic/browser/downloads/wolvic_download_manager_delegate.h"
 #include "wolvic/wolvic_permission_manager.h"
@@ -132,23 +133,9 @@ void WolvicBrowserContext::CreatePasswordStore() {
           ->GetURLLoaderFactoryForBrowserProcess();
   auto backend_task_runner = base::ThreadPool::CreateSequencedTaskRunner(
       {base::MayBlock(), base::TaskPriority::USER_VISIBLE});
-  affiliation_service_ =
-          std::make_unique<password_manager::AffiliationServiceImpl>(
-              url_loader_factory, backend_task_runner);
-
-  base::FilePath database_path =
-      GetPrefStorePath().Append(
-          password_manager::kAffiliationDatabaseFileName);
-  affiliation_service_->Init(content::GetNetworkConnectionTracker(),
-                            database_path);
-
-  auto affiliated_match_helper =
-      std::make_unique<password_manager::AffiliatedMatchHelper>(
-          affiliation_service_.get());
-
   password_store_ = new password_manager::PasswordStore(
       std::make_unique<wolvic::WolvicPasswordStoreBackend>());
-  password_store_->Init(GetPrefService(), std::move(affiliated_match_helper));
+  password_store_->Init(GetPrefService(), nullptr);
 }
 
 void WolvicBrowserContext::CreateIdentityManger() {
@@ -161,6 +148,7 @@ void WolvicBrowserContext::CreateIdentityManger() {
   params.network_connection_tracker = content::GetNetworkConnectionTracker();
   params.pref_service = GetPrefService();
   params.profile_path = GetPrefStorePath();
+  params.image_decoder = std::make_unique<wolvic::WolvicImageDecoder>();
   identity_manager_ = signin::BuildIdentityManager(&params);
 }
 

--- a/wolvic/wolvic_browser_context.h
+++ b/wolvic/wolvic_browser_context.h
@@ -10,7 +10,6 @@
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "components/autofill/core/browser/autocomplete_history_manager.h"
-#include "components/password_manager/core/browser/affiliation/affiliation_service_impl.h"
 #include "components/password_manager/core/browser/field_info_manager.h"
 #include "components/password_manager/core/browser/password_store.h"
 #include "components/prefs/pref_name_set.h"
@@ -134,7 +133,6 @@ class WolvicBrowserContext : public BrowserContext,
   base::FilePath path_;
   std::unique_ptr<SimpleFactoryKey> key_;
   std::unique_ptr<visitedlink::VisitedLinkWriter> visitedlink_writer_;
-  std::unique_ptr<password_manager::AffiliationServiceImpl> affiliation_service_;
   std::unique_ptr<autofill::AutocompleteHistoryManager> autocomplete_history_manager_;
   scoped_refptr<password_manager::PasswordStore> password_store_;
   std::unique_ptr<password_manager::FieldInfoManager> field_info_manager_;


### PR DESCRIPTION
This patch fixes the DCHECK crash caused by the implementation of Passworkd Manager.
- Added WolvicImageDecoder since IdentityManager requires a valid ImageDecoder instance when initializing.
- Nullable Java string should check empty before calling ConvertJavaStringTo{UTF8/UTF16}
- Avoid DCHECK through a fake url of credential since the update status requires the credential info or the saved PasswordForm when adding the new ID/PW via PasswordFormManagerForUI::Update
- Remove AffiliationService to delegate the PasswordForm check in Wolvic Implementations