### PR TITLE
Open the new window with WebContents instead of initial url

### DIFF
--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -57,6 +57,26 @@ ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
   return web_contents_impl->GetJavaWebContents();
 }
 
+void JNI_Tab_AttachWebContents(JNIEnv* env,
+                            const JavaParamRef<jobject>& jweb_contents) {
+  WebContents* web_contents = WebContents::FromJavaWebContents(jweb_contents);
+  DCHECK(web_contents);
+  auto wolvic_contents = std::make_unique<WolvicContents>(
+      std::unique_ptr<WebContents>(web_contents));
+  wolvic_contents.release()->Init();
+  web_contents->ResumeLoadingCreatedWebContents();
+}
+
+void JNI_Tab_ReleaseWebContents(JNIEnv* env,
+                                const JavaParamRef<jobject>& jweb_contents) {
+  WebContents* web_contents = WebContents::FromJavaWebContents(jweb_contents);
+  DCHECK(web_contents);
+
+  auto* wolvic_contents = WolvicContents::FromWebContents(web_contents);
+  DCHECK(wolvic_contents);
+  delete wolvic_contents;
+}
+
 void JNI_Tab_SetWebContentsDelegate(
     JNIEnv* env,
     const JavaParamRef<jobject>& jweb_contents,

--- a/wolvic/browser/wolvic_contents.cc
+++ b/wolvic/browser/wolvic_contents.cc
@@ -34,7 +34,7 @@ class WolvicContentsUserData : public base::SupportsUserData::Data {
   }
 
  private:
-  std::unique_ptr<WolvicContents> contents_;
+  raw_ptr<WolvicContents> contents_;
 };
 
 // static

--- a/wolvic/browser/wolvic_web_contents_delegate.cc
+++ b/wolvic/browser/wolvic_web_contents_delegate.cc
@@ -27,9 +27,8 @@ WolvicWebContentsDelegate::~WolvicWebContentsDelegate() = default;
 
 using base::android::ScopedJavaLocalRef;
 
-// Called by web_contents_impl.cc whenever a navigation
-// requires the creation of a new window (for example
-// a link with target=_blank
+// Called by web_contents_impl.cc whenever a navigation requires the creation
+// of a new window (for example a link with target=_blank and window.open)
 void WolvicWebContentsDelegate::AddNewContents(
     content::WebContents* source,
     std::unique_ptr<content::WebContents> new_contents,
@@ -38,21 +37,24 @@ void WolvicWebContentsDelegate::AddNewContents(
     const blink::mojom::WindowFeatures& window_features,
     bool user_gesture,
     bool* was_blocked) {
-
   JNIEnv* env = base::android::AttachCurrentThread();
   ScopedJavaLocalRef<jobject> java_delegate = GetJavaDelegate(env);
   if (java_delegate.is_null())
     return;
 
-  // We let new_contents die on purpouse (by not assigning the
-  // unique_ptr to any local variable/attribute because that way
-  // we are telling the web engine that we do not want a new
-  // window to be created. We'll in any case use the target_urlformatter
-  // to notify the client (Wolvic) so that it can create the window
-  // for the new URL on its own.
-  ScopedJavaLocalRef<jobject> java_gurl =
-      url::GURLAndroid::FromNativeGURL(env, target_url);
-  Java_WolvicWebContentsDelegate_onCreateNewWindow(env, java_delegate, java_gurl);
+  Java_WolvicWebContentsDelegate_onCreateNewWindow(
+      env, java_delegate, new_contents->GetJavaWebContents());
+
+  // |new_contents| ownership has been passed to java, and will retake it
+  // in WolvicWebContents when the new tab is created asynchronously.
+  new_contents.release();
+}
+
+bool WolvicWebContentsDelegate::ShouldResumeRequestsForCreatedWindow() {
+  // Always return false here since we need to defer loading the created window
+  // until after we have attached a new delegate to the new webcontents (which
+  // happens asynchronously).
+  return false;
 }
 
 // This adds an extra null check to the parent's behaviour. Seems to be needed

--- a/wolvic/browser/wolvic_web_contents_delegate.h
+++ b/wolvic/browser/wolvic_web_contents_delegate.h
@@ -29,6 +29,7 @@ class WolvicWebContentsDelegate
                       const blink::mojom::WindowFeatures& window_features,
                       bool user_gesture,
                       bool* was_blocked) final;
+  bool ShouldResumeRequestsForCreatedWindow() override;
 
   content::JavaScriptDialogManager* GetJavaScriptDialogManager(
       content::WebContents* source) final;

--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -44,12 +44,20 @@ public class Tab {
         return TabJni.get().createWebContents(is_off_the_record);
     }
 
+    private void attachWebContents(WebContents mWebContents) {
+        TabJni.get().attachWebContents(mWebContents);
+    }
+
+    private void releaseWebContents(WebContents webContents) {
+        TabJni.get().releaseWebContents(webContents);
+    }
+
     public void setWebContentsDelegate(
             WebContents webContents, WolvicWebContentsDelegate delegate) {
         TabJni.get().setWebContentsDelegate(webContents, delegate);
     }
 
-    public Tab(@NonNull Context context, boolean is_off_the_record) {
+    public Tab(@NonNull Context context, boolean is_off_the_record, WebContents webContents) {
         mWindowAndroid = new ActivityWindowAndroid(context, false,
                 IntentRequestTracker.createFromActivity(ContextUtils.activityFromContext(context)));
 
@@ -57,7 +65,12 @@ public class Tab {
         mCompositorView.onNativeLibraryLoaded(mWindowAndroid);
         mWindowAndroid.setAnimationPlaceholderView(mCompositorView);
 
-        mWebContents = createWebContents(is_off_the_record);
+        if (webContents != null) {
+            mWebContents = webContents;
+            attachWebContents(mWebContents);
+        } else {
+            mWebContents = createWebContents(is_off_the_record);
+        }
 
         mContentView =
                 ContentView.createContentView(context, null /* eventOffsetHandler */, mWebContents);
@@ -71,6 +84,18 @@ public class Tab {
         // TODO: Call `onShow()` on the appropriate place and should be pair
         // with `onHide()`.
         mWebContents.onShow();
+    }
+
+    public void destroy() {
+        mWindowAndroid = null;
+        mContentView = null;
+        mNavigationController = null;;
+        mCompositorView = null;;
+
+        if (!mWebContents.isDestroyed()) {
+            releaseWebContents(mWebContents);
+        }
+        mWebContents = null;
     }
 
     public void goBack() {
@@ -150,6 +175,8 @@ public class Tab {
     @NativeMethods
     public interface Natives {
         WebContents createWebContents(boolean is_off_the_record);
+        void attachWebContents(WebContents webContents);
+        void releaseWebContents(WebContents webContents);
         void setWebContentsDelegate(WebContents webContents, WolvicWebContentsDelegate delegate);
         void pageZoomIn(WebContents webContents);
         void pageZoomOut(WebContents webContents);

--- a/wolvic/java/org/chromium/wolvic/WolvicWebContentsDelegate.java
+++ b/wolvic/java/org/chromium/wolvic/WolvicWebContentsDelegate.java
@@ -6,13 +6,13 @@ package org.chromium.wolvic;
 
 import androidx.annotation.VisibleForTesting;
 
-import org.chromium.url.GURL;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.components.embedder_support.delegate.WebContentsDelegateAndroid;
+import org.chromium.content_public.browser.WebContents;
 
 @JNINamespace("wolvic")
 public abstract class WolvicWebContentsDelegate extends WebContentsDelegateAndroid {
     @CalledByNative
-    public abstract void onCreateNewWindow(GURL url);
+    public abstract void onCreateNewWindow(WebContents webContents);
 }


### PR DESCRIPTION
This patch changes the opening window's parameter as WebContents instead of initial url so that keeps the connection of a parent window and a child window(=the popup). Also the patch changes a management of WebContents lifecycle to fix the leakage of it.