### PR TITLE
Fix WebXR's spinning issue

### DIFF
--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -47,8 +47,8 @@ device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
 
 gfx::Transform GetFloorTransform(const float matrix[16]) {
   gfx::Transform transform;
-  WvrMatToTransform(matrix, &transform);
-  return transform.GetCheckedInverse();
+  transform.Translate3d(0, -1 * matrix[13], 0);
+  return transform;
 }
 
 device::mojom::XRHandedness ToXRHandness(mozilla::gfx::ControllerHand hand) {


### PR DESCRIPTION
This patch changes to use only the eye height for the space's standing height from the floor so that fixes the spinning issue when loading Archery Evolution WebXR game from the heyvr.io site.

Also, the standing height is multiplied by -1 according to the patch reflection of crrev.com/c/2278317.