### PR TITLE
Add PicoNeo3 support

### DIFF
--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -153,6 +153,7 @@ enum class VRControllerType : uint8_t {
   PicoGaze,
   PicoG2,
   PicoNeo2,
+  PicoNeo3,
   Pico4,
   MetaQuest3,
   MagicLeap2,

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -456,6 +456,10 @@ static void PopulateProfiles(
       input_source->description->profiles = {
           "pico-neo2", "generic-trigger-squeeze-thumbstick"};
       break;
+    case mozilla::gfx::VRControllerType::PicoNeo3:
+      input_source->description->profiles = {
+          "pico-neo3", "generic-trigger-squeeze-thumbstick"};
+      break;
     case mozilla::gfx::VRControllerType::Pico4:
       input_source->description->profiles = {
           "pico-4", "generic-trigger-squeeze-thumbstick"};


### PR DESCRIPTION
Wolvic already had support for that device. The problem was not that the Neo3 was not properly select but also all the other device whose enumerated type definitions were bellow the PicoNeo3 like the Quest3 or the MagicLeap2 that were not selecting the proper WebXR profile and thus loading the incorrect 3D model.