### PR TITLE
Fix mojo_from_floor transformation

### DIFF
--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -45,12 +45,6 @@ device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
   return pose;
 }
 
-gfx::Transform GetFloorTransform(const float matrix[16]) {
-  gfx::Transform transform;
-  WvrMatToTransform(matrix, &transform);
-  return transform.GetCheckedInverse();
-}
-
 device::mojom::XRHandedness ToXRHandness(mozilla::gfx::ControllerHand hand) {
   using mozilla::gfx::ControllerHand;
   switch (hand) {
@@ -678,14 +672,17 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
 
   frame_data->time_delta = now - base::TimeTicks();
 
-  gfx::Transform transform = GetFloorTransform(system_state.displayState.sittingToStandingTransform);
-  if (floor_transform_ != transform) {
+  // On 3D graphics the translation on a 4x4 transform matrix is stored in the first 3 values of
+  // the 4th column. This means that (x,y,z) are on indexes (12, 13, 14).
+  auto floor_height = system_state.displayState.sittingToStandingTransform[13];
+  if (floor_height_ != floor_height) {
     frame_data->stage_parameters_id = ++stage_parameters_id_;
-    floor_transform_ = transform;
+    floor_height_ = floor_height;
   }
 
   frame_data->stage_parameters = device::mojom::VRStageParameters::New();
-  frame_data->stage_parameters->mojo_from_floor = floor_transform_;
+  frame_data->stage_parameters->mojo_from_floor = gfx::Transform();
+  frame_data->stage_parameters->mojo_from_floor.Translate3d(0, -floor_height_, 0);
 
   std::move(get_frame_data_callback_).Run(std::move(frame_data));
 }

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -45,12 +45,6 @@ device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
   return pose;
 }
 
-gfx::Transform GetFloorTransform(const float matrix[16]) {
-  gfx::Transform transform;
-  WvrMatToTransform(matrix, &transform);
-  return transform.GetCheckedInverse();
-}
-
 device::mojom::XRHandedness ToXRHandness(mozilla::gfx::ControllerHand hand) {
   using mozilla::gfx::ControllerHand;
   switch (hand) {
@@ -676,16 +670,10 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
 
   frame_data->mojo_from_viewer = PoseToVRPosePtr(pose);
 
+  // FIXME: this is wrong we should get a predicted display time from Wolvic.
   frame_data->time_delta = now - base::TimeTicks();
 
-  gfx::Transform transform = GetFloorTransform(system_state.displayState.sittingToStandingTransform);
-  if (floor_transform_ != transform) {
-    frame_data->stage_parameters_id = ++stage_parameters_id_;
-    floor_transform_ = transform;
-  }
-
   frame_data->stage_parameters = device::mojom::VRStageParameters::New();
-  frame_data->stage_parameters->mojo_from_floor = floor_transform_;
 
   std::move(get_frame_data_callback_).Run(std::move(frame_data));
 }

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -45,6 +45,12 @@ device::mojom::VRPosePtr PoseToVRPosePtr(const mozilla::gfx::VRPose* p) {
   return pose;
 }
 
+gfx::Transform GetFloorTransform(const float matrix[16]) {
+  gfx::Transform transform;
+  WvrMatToTransform(matrix, &transform);
+  return transform.GetCheckedInverse();
+}
+
 device::mojom::XRHandedness ToXRHandness(mozilla::gfx::ControllerHand hand) {
   using mozilla::gfx::ControllerHand;
   switch (hand) {
@@ -670,10 +676,16 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
 
   frame_data->mojo_from_viewer = PoseToVRPosePtr(pose);
 
-  // FIXME: this is wrong we should get a predicted display time from Wolvic.
   frame_data->time_delta = now - base::TimeTicks();
 
+  gfx::Transform transform = GetFloorTransform(system_state.displayState.sittingToStandingTransform);
+  if (floor_transform_ != transform) {
+    frame_data->stage_parameters_id = ++stage_parameters_id_;
+    floor_transform_ = transform;
+  }
+
   frame_data->stage_parameters = device::mojom::VRStageParameters::New();
+  frame_data->stage_parameters->mojo_from_floor = floor_transform_;
 
   std::move(get_frame_data_callback_).Run(std::move(frame_data));
 }

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -123,7 +123,7 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   bool is_frame_submmitted_ = false;
   base::OnceClosure pending_getframedata_;
 
-  gfx::Transform floor_transform_;
+  float floor_height_;
   uint32_t stage_parameters_id_ = 0;
 
   // Communicate with the renderer.

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -123,7 +123,6 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   bool is_frame_submmitted_ = false;
   base::OnceClosure pending_getframedata_;
 
-  gfx::Transform floor_transform_;
   uint32_t stage_parameters_id_ = 0;
 
   // Communicate with the renderer.

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -123,6 +123,7 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   bool is_frame_submmitted_ = false;
   base::OnceClosure pending_getframedata_;
 
+  gfx::Transform floor_transform_;
   uint32_t stage_parameters_id_ = 0;
 
   // Communicate with the renderer.


### PR DESCRIPTION
We were getting an incorrect pose when starting WebXR experiences. The front was rotated 90 or 180 degrees on the Y axis. The position was also a bit ankward, not definitely at the origin of coordinates. The problem was that mojo_from_floor was computed as the location of the stage space from the local space. In order to do that
we were basically inverting the sittingToStandingiTransform which is precisely the opposite, the location of the local space from the stage space. That should be fine but it looks like it is not what the Chromium WebXR code expects.
    
That's why we decided to switch that to what ARCore backend does which is to only use the Y coordinate. In theory that should be actually the only difference between local and stage at least before moving.

