### PR TITLE
Do not reset the reference space on every frame

### DIFF
--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -664,8 +664,6 @@ void WvrManager::WebXrTryStartAnimatingFrame() {
 
   frame_data->views = CreateViews(wvr_api_, pose);
 
-  frame_data->mojo_space_reset = true;
-
   frame_data->input_state = GetInputSourceState();
 
   frame_data->mojo_from_viewer = PoseToVRPosePtr(pose);


### PR DESCRIPTION
Resetting the reference space must be done only when the origin changes signigicantly, for example as a response to a long click on the menu button of a controller (like when recentering the view).

The code was doing it on every frame unconditionally instead. This is wrong and was causing weird behaviours in several WebXR experiences.

Fixes Wolvic's https://github.com/Igalia/wolvic/issues/1296