### PR TITLE
Enable AR support in the Wolvic device

### DIFF
--- a/content/browser/xr/service/xr_runtime_manager_impl.cc
+++ b/content/browser/xr/service/xr_runtime_manager_impl.cc
@@ -337,6 +337,11 @@ BrowserXRRuntimeImpl* XRRuntimeManagerImpl::GetImmersiveArRuntime() {
   }
 #endif
 
+  auto* wolvic_runtime = GetRuntime(device::mojom::XRDeviceId::WVR_DEVICE_ID);
+  if (wolvic_runtime && wolvic_runtime->SupportsArBlendMode()) {
+    return wolvic_runtime;
+  }
+
   return nullptr;
 }
 

--- a/wolvic/browser/vr/moz_external_vr.h
+++ b/wolvic/browser/vr/moz_external_vr.h
@@ -50,7 +50,7 @@ namespace gfx {
 // running at the same time? Or...what if we have multiple
 // release builds running on same machine? (Bug 1563232)
 #define SHMEM_VERSION "0.0.11"
-static const int32_t kVRExternalVersion = 19;
+static const int32_t kVRExternalVersion = 20;
 
 // We assign VR presentations to groups with a bitmask.
 // Currently, we will only display either content or chrome.
@@ -70,6 +70,7 @@ static const int kVRControllerMaxButtons = 64;
 static const int kVRControllerMaxAxis = 16;
 static const int kVRLayerMaxCount = 8;
 static const int kVRHapticsMaxCount = 32;
+static const int kVRBlendModesMaxLen = 3;
 
 #if defined(__ANDROID__)
 typedef uint64_t VRLayerTextureHandle;
@@ -164,7 +165,14 @@ enum class TargetRayMode : uint8_t { Gaze, TrackedPointer, Screen };
 
 enum class GamepadMappingType : uint8_t { _empty, Standard, XRStandard };
 
-enum class VRDisplayBlendMode : uint8_t { Opaque, Additive, AlphaBlend };
+enum class VRDisplayBlendMode : uint8_t {
+  _empty,
+  Opaque,
+  Additive,
+  AlphaBlend
+};
+
+enum class ImmersiveXRSessionType : uint8_t { VR, AR };
 
 enum class VRDisplayCapabilityFlags : uint16_t {
   Cap_None = 0,
@@ -348,7 +356,7 @@ struct VRDisplayState {
   //                             ('B'<<8) + 'A').
   uint64_t eightCC;
   VRDisplayCapabilityFlags capabilityFlags;
-  VRDisplayBlendMode blendMode;
+  VRDisplayBlendMode blendModes[kVRBlendModesMaxLen];
   VRFieldOfView eyeFOV[VRDisplayState::NumEyes];
   float eyeTransform[VRDisplayState::NumEyes][16];
   IntSize_POD eyeResolution;
@@ -544,6 +552,8 @@ struct VRBrowserState {
   bool dropFame;
   VRLayerState layerState[kVRLayerMaxCount];
   VRHapticState hapticState[kVRHapticsMaxCount];
+  VRDisplayBlendMode blendMode;
+  ImmersiveXRSessionType sessionType;
 
 #ifdef MOZILLA_INTERNAL_API
   void Clear() { memset(this, 0, sizeof(VRBrowserState)); }

--- a/wolvic/browser/vr/wvr_api.cc
+++ b/wolvic/browser/vr/wvr_api.cc
@@ -86,7 +86,9 @@ bool WvrApi::PresentingGenerationChanged() {
 
 bool WvrApi::SyncState(bool is_frame_submmitted,
                        int32_t texture_handle,
-                       const gfx::Size& size) {
+                       const gfx::Size& size,
+                       mozilla::gfx::VRDisplayBlendMode blend_mode,
+                       mozilla::gfx::ImmersiveXRSessionType session_type) {
   if (is_frame_submmitted) {
     ++sync_frame_index_;
   }
@@ -109,6 +111,8 @@ bool WvrApi::SyncState(bool is_frame_submmitted,
   }
 
   browser_state_.dropFame = !is_frame_submmitted;
+  browser_state_.blendMode = blend_mode;
+  browser_state_.sessionType = session_type;
   uint64_t oldDroppedFrameCount = system_state_.displayState.droppedFrameCount;
   PushState(NotifyCondition::YES);
   PullState([this, oldDroppedFrameCount]() {

--- a/wolvic/browser/vr/wvr_api.h
+++ b/wolvic/browser/vr/wvr_api.h
@@ -28,7 +28,9 @@ class WvrApi {
   bool PresentingGenerationChanged();
   bool SyncState(bool is_frame_submmitted,
                  int32_t texture_handle,
-                 const gfx::Size& size);
+                 const gfx::Size& size,
+                 mozilla::gfx::VRDisplayBlendMode,
+                 mozilla::gfx::ImmersiveXRSessionType);
   void PullSystemState();
 
   mozilla::gfx::VRSystemState get_system_state() { return system_state_; }

--- a/wolvic/browser/vr/wvr_device.cc
+++ b/wolvic/browser/vr/wvr_device.cc
@@ -49,6 +49,7 @@ WvrDevice::WvrDevice()
   }
 
   SetSupportedFeatures(device_features);
+  SetArBlendModeSupported(true);
 }
 
 WvrDevice::~WvrDevice() {

--- a/wolvic/browser/vr/wvr_manager.cc
+++ b/wolvic/browser/vr/wvr_manager.cc
@@ -318,10 +318,35 @@ void WvrManager::ConnectPresentingService(
   config->views = std::move(views);
   config->supports_viewport_scaling = true;
   session->enviroment_blend_mode =
-      device::mojom::XREnvironmentBlendMode::kOpaque;
+      PickEnvironmentBlendModeForSession(options->mode);
   config->default_framebuffer_scale =
       wvr_api_->get_system_state().displayState.nativeFramebufferScaleFactor;
   session->interaction_mode = device::mojom::XRInteractionMode::kScreenSpace;
+
+  auto toGfxBlendMode = [](device::mojom::XREnvironmentBlendMode mode) {
+    switch (mode) {
+      case device::mojom::XREnvironmentBlendMode::kOpaque:
+        return mozilla::gfx::VRDisplayBlendMode::Opaque;
+      case device::mojom::XREnvironmentBlendMode::kAlphaBlend:
+        return mozilla::gfx::VRDisplayBlendMode::AlphaBlend;
+      case device::mojom::XREnvironmentBlendMode::kAdditive:
+        return mozilla::gfx::VRDisplayBlendMode::Additive;
+    }
+  };
+  blend_mode_ = toGfxBlendMode(session->enviroment_blend_mode);
+
+  auto toGfxSessionType = [](device::mojom::XRSessionMode mode) {
+    switch (mode) {
+      case device::mojom::XRSessionMode::kImmersiveVr:
+        return mozilla::gfx::ImmersiveXRSessionType::VR;
+      case device::mojom::XRSessionMode::kImmersiveAr:
+        return mozilla::gfx::ImmersiveXRSessionType::AR;
+      case device::mojom::XRSessionMode::kInline:
+        NOTREACHED();
+        return mozilla::gfx::ImmersiveXRSessionType::VR;
+    }
+  };
+  session_type_ = toGfxSessionType(options->mode);
 
   std::move(callback).Run(std::move(session));
 }
@@ -710,9 +735,9 @@ bool WvrManager::SubmitFrameInternal(int16_t frame_index) {
     return false;
   }
 
-  if (!wvr_api_->SyncState(is_frame_submmitted_,
-                           graphics_->webxr_texture_handle(),
-                           graphics_->webxr_surface_size())) {
+  if (!wvr_api_->SyncState(
+          is_frame_submmitted_, graphics_->webxr_texture_handle(),
+          graphics_->webxr_surface_size(), blend_mode_, session_type_)) {
     DLOG(WARNING) << __func__
                   << "SyncState failed. Don't submit frame";
     return false;
@@ -848,6 +873,66 @@ void WvrManager::UpdateLayerBounds(int16_t frame_index,
   }
 
   CreateOrResizeWebXrSurface(source_size);
+}
+
+device::mojom::XREnvironmentBlendMode
+WvrManager::PickEnvironmentBlendModeForSession(
+    device::mojom::XRSessionMode session_mode) {
+  DCHECK(wvr_api_->get_system_state().enumerationCompleted);
+
+  const auto& display_state = wvr_api_->get_system_state().displayState;
+  auto supportsBlendMode =
+      [&display_state](const mozilla::gfx::VRDisplayBlendMode blend_mode) {
+        for (auto& supported_blend_mode : display_state.blendModes) {
+          if (supported_blend_mode ==
+              mozilla::gfx::VRDisplayBlendMode::_empty) {
+            return false;
+          }
+          if (supported_blend_mode == blend_mode) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+  switch (session_mode) {
+    case device::mojom::XRSessionMode::kImmersiveVr:
+      if (supportsBlendMode(mozilla::gfx::VRDisplayBlendMode::Opaque)) {
+        return device::mojom::XREnvironmentBlendMode::kOpaque;
+      }
+      break;
+    case device::mojom::XRSessionMode::kImmersiveAr:
+      // Prefer Alpha Blend when both Alpha Blend and Additive modes are
+      // supported. This only concerns video see through devices with an
+      // Additive compatibility mode
+      if (supportsBlendMode(mozilla::gfx::VRDisplayBlendMode::AlphaBlend)) {
+        return device::mojom::XREnvironmentBlendMode::kAlphaBlend;
+      }
+
+      if (supportsBlendMode(mozilla::gfx::VRDisplayBlendMode::Additive)) {
+        return device::mojom::XREnvironmentBlendMode::kAdditive;
+      }
+
+      break;
+    case device::mojom::XRSessionMode::kInline:
+      NOTREACHED();
+  }
+
+  auto toMojoBlendMode = [](mozilla::gfx::VRDisplayBlendMode mode) {
+    switch (mode) {
+      case mozilla::gfx::VRDisplayBlendMode::Opaque:
+        return device::mojom::XREnvironmentBlendMode::kOpaque;
+      case mozilla::gfx::VRDisplayBlendMode::AlphaBlend:
+        return device::mojom::XREnvironmentBlendMode::kAlphaBlend;
+      case mozilla::gfx::VRDisplayBlendMode::Additive:
+        return device::mojom::XREnvironmentBlendMode::kAdditive;
+      case mozilla::gfx::VRDisplayBlendMode::_empty:
+        NOTREACHED();
+        return device::mojom::XREnvironmentBlendMode::kOpaque;
+    }
+  };
+
+  return toMojoBlendMode(display_state.blendModes[0]);
 }
 
 }  // namespace wolvic

--- a/wolvic/browser/vr/wvr_manager.h
+++ b/wolvic/browser/vr/wvr_manager.h
@@ -117,6 +117,9 @@ class WvrManager : public device::mojom::XRPresentationProvider,
   void ClosePresentationBindings();
   void OnSubmitClientMojoConnectionError();
 
+  device::mojom::XREnvironmentBlendMode PickEnvironmentBlendModeForSession(
+      device::mojom::XRSessionMode);
+
   device::mojom::XRFrameDataProvider::GetFrameDataCallback
       get_frame_data_callback_;
 
@@ -146,6 +149,9 @@ class WvrManager : public device::mojom::XRPresentationProvider,
 
   mozilla::gfx::VRControllerState
       controller_state_[mozilla::gfx::kVRControllerMaxCount];
+
+  mozilla::gfx::VRDisplayBlendMode blend_mode_;
+  mozilla::gfx::ImmersiveXRSessionType session_type_;
 
   base::WeakPtrFactory<WvrManager> weak_ptr_factory_{this};
 };


### PR DESCRIPTION
This involves a few different changes. So far we have been forcing the blend mode to opaque because we were only supporting immersive-vr WebXR sessions. In order to properly support AR cases we need to select the blend mode depending on the session type and also the available blend modes provided by Wolvic. Also the device should advertise itself as AR capable.

However that is not enough for devices like Meta's Quest because they only support opaque blend modes although passthrough is supported via a special compositor layer. For those devices we need to notify Wolvic that the browser wants to start an immersive AR session so Wolvic could decide the exact mechanism to use, either an AR compatible blend mode (like for Pico4E) or a passthrough compositor layer (like in the case of Quest3).