### PR TITLE
Remove redundant and unwanted build checks

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -202,22 +202,17 @@ static_library("content_native_lib") {
     "//services/network:network_service",
   ]
   deps = [
-    ":pak",
+   ":pak",
     "//base",
     "//base:base_static",
     "//base/third_party/dynamic_annotations",
     "//build:chromeos_buildflags",
     "//cc/base",
-    "//components/autofill/content/browser",
-    "//components/autofill/content/renderer",
     "//components/cdm/browser",
     "//components/cdm/common",
     "//components/cdm/renderer",
-    "//components/crash/content/browser",
-    "//components/crash/core/app",
     "//components/custom_handlers",
     "//components/embedder_support:browser_util",
-    "//components/embedder_support/android:view",
     "//components/embedder_support/android:web_contents_delegate",
     "//components/keyed_service/content",
     "//components/metrics",
@@ -227,23 +222,24 @@ static_library("content_native_lib") {
     "//components/network_session_configurator/common",
     "//components/origin_trials:browser",
     "//components/origin_trials:common",
-    "//components/password_manager/content/browser",
+    "//components/autofill/content/renderer",
+    "//components/autofill/content/browser",
     "//components/password_manager/content/common",
+    "//components/password_manager/content/browser",
     "//components/performance_manager",
     "//components/permissions",
     "//components/prefs",
-    "//components/strings",
     "//components/url_formatter",
     "//components/variations",
     "//components/variations/service",
     "//components/visitedlink/browser",
     "//components/visitedlink/renderer",
+    "//components/strings",
     "//components/web_cache/renderer",
     "//components/webxr:webxr",
     "//content:content_resources",
     "//content/common:main_frame_counter",
     "//content/public/common",
-    "//content/shell/android:content_shell_jni_headers",
     "//content/test:content_test_mojo_bindings",
     "//device/bluetooth",
     "//media",
@@ -259,7 +255,6 @@ static_library("content_native_lib") {
     "//third_party/blink/public:resources",
     "//third_party/blink/public/strings",
     "//third_party/blink/public/strings:accessibility_strings",
-    "//ui/android",
     "//ui/base",
     "//ui/base/clipboard",
     "//ui/base/ime/init",
@@ -268,6 +263,17 @@ static_library("content_native_lib") {
     "//ui/platform_window",
     "//url",
     "//v8",
+  ]
+
+  deps += [
+    "//components/crash/content/browser",
+    "//components/crash/core/app",
+  ]
+
+  deps += [
+    "//components/embedder_support/android:view",
+    "//content/shell/android:content_shell_jni_headers",
+    "//ui/android",
   ]
 }
 

--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -202,17 +202,22 @@ static_library("content_native_lib") {
     "//services/network:network_service",
   ]
   deps = [
-   ":pak",
+    ":pak",
     "//base",
     "//base:base_static",
     "//base/third_party/dynamic_annotations",
     "//build:chromeos_buildflags",
     "//cc/base",
+    "//components/autofill/content/browser",
+    "//components/autofill/content/renderer",
     "//components/cdm/browser",
     "//components/cdm/common",
     "//components/cdm/renderer",
+    "//components/crash/content/browser",
+    "//components/crash/core/app",
     "//components/custom_handlers",
     "//components/embedder_support:browser_util",
+    "//components/embedder_support/android:view",
     "//components/embedder_support/android:web_contents_delegate",
     "//components/keyed_service/content",
     "//components/metrics",
@@ -222,24 +227,23 @@ static_library("content_native_lib") {
     "//components/network_session_configurator/common",
     "//components/origin_trials:browser",
     "//components/origin_trials:common",
-    "//components/autofill/content/renderer",
-    "//components/autofill/content/browser",
-    "//components/password_manager/content/common",
     "//components/password_manager/content/browser",
+    "//components/password_manager/content/common",
     "//components/performance_manager",
     "//components/permissions",
     "//components/prefs",
+    "//components/strings",
     "//components/url_formatter",
     "//components/variations",
     "//components/variations/service",
     "//components/visitedlink/browser",
     "//components/visitedlink/renderer",
-    "//components/strings",
     "//components/web_cache/renderer",
     "//components/webxr:webxr",
     "//content:content_resources",
     "//content/common:main_frame_counter",
     "//content/public/common",
+    "//content/shell/android:content_shell_jni_headers",
     "//content/test:content_test_mojo_bindings",
     "//device/bluetooth",
     "//media",
@@ -255,6 +259,7 @@ static_library("content_native_lib") {
     "//third_party/blink/public:resources",
     "//third_party/blink/public/strings",
     "//third_party/blink/public/strings:accessibility_strings",
+    "//ui/android",
     "//ui/base",
     "//ui/base/clipboard",
     "//ui/base/ime/init",
@@ -264,23 +269,6 @@ static_library("content_native_lib") {
     "//url",
     "//v8",
   ]
-
-  if (is_fuchsia) {
-    deps += [ "//third_party/fuchsia-sdk/sdk/fidl/fuchsia.ui.policy" ]
-  } else {
-    deps += [
-      "//components/crash/content/browser",
-      "//components/crash/core/app",
-    ]
-  }
-
-  if (is_android) {
-    deps += [
-      "//components/embedder_support/android:view",
-      "//content/shell/android:content_shell_jni_headers",
-      "//ui/android",
-    ]
-  }
 }
 
 generate_build_config_srcjar("build_config_gen") {


### PR DESCRIPTION
Currently, wolvic/BUILD.gn is accessible only to Android builds through an `assert(is_android)` check. This change removes unnecessary build configurations that were previously guarded by `is_android` an `is_fuchsia`, as they no longer seem relevant.