### PR TITLE
Improve startup logging

### DIFF
--- a/wolvic/wolvic_content_main_delegate.cc
+++ b/wolvic/wolvic_content_main_delegate.cc
@@ -170,13 +170,11 @@ WolvicContentMainDelegate* WolvicContentMainDelegate::Get() {
 }
 
 absl::optional<int> WolvicContentMainDelegate::BasicStartupComplete() {
-  LOG(ERROR) << "WolvicLifecycle BasicStartupComplete()";
   Compositor::Initialize();
 
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
   InitLogging(command_line);
-  LOG(ERROR) << "WolvicLifecycle command_line="
-             << command_line.GetCommandLineString();
+  LOG(INFO) << "Command line: " << command_line.GetCommandLineString();
   RegisterShellPathProvider();
 
   return absl::nullopt;
@@ -297,7 +295,6 @@ ContentClient* WolvicContentMainDelegate::CreateContentClient() {
 }
 
 ContentBrowserClient* WolvicContentMainDelegate::CreateContentBrowserClient() {
-  LOG(ERROR) << "WolvicLifecycle CreateContentBrowserClient()";
   browser_client_ = std::make_unique<WolvicContentBrowserClient>();
   return browser_client_.get();
 }


### PR DESCRIPTION
On the one hand there were too much debugging, some log messages were not useful at all. On the other hand, they're all using ERROR for messages that didn't involve error conditions.

That's why we're removing not needed messages and switched the valid ones to INFO log level.