### PR TITLE
Add WolvicBrowserContext java class

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -302,6 +302,7 @@ generate_jni("jni_headers") {
     "java/org/chromium/wolvic/UserDialogManagerBridge.java",
     "java/org/chromium/wolvic/VRManager.java",
     "java/org/chromium/wolvic/WVRSurfaceTexture.java",
+    "java/org/chromium/wolvic/WolvicBrowserContext.java",
     "java/org/chromium/wolvic/WolvicWebContentsDelegate.java",
   ]
 }
@@ -323,6 +324,7 @@ android_library("wolvic_java") {
     "java/org/chromium/wolvic/UserDialogManagerBridge.java",
     "java/org/chromium/wolvic/VRManager.java",
     "java/org/chromium/wolvic/WVRSurfaceTexture.java",
+    "java/org/chromium/wolvic/WolvicBrowserContext.java",
     "java/org/chromium/wolvic/WolvicWebContentsDelegate.java",
   ]
   srcjar_deps = [ ":jni_headers" ]

--- a/wolvic/java/org/chromium/wolvic/WolvicBrowserContext.java
+++ b/wolvic/java/org/chromium/wolvic/WolvicBrowserContext.java
@@ -1,0 +1,57 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import org.jni_zero.CalledByNative;
+import org.jni_zero.JNINamespace;
+import org.jni_zero.NativeMethods;
+
+import org.chromium.content_public.browser.BrowserContextHandle;
+import org.chromium.content_public.browser.RenderFrameHost;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.content_public.browser.WebContentsStatics;
+
+@JNINamespace("wolvic")
+public class WolvicBrowserContext implements BrowserContextHandle {
+    /** Pointer to the Native-side WolvicBrowserContext. */
+    private long mNativeWolvicBrowserContext;
+
+    public static BrowserContextHandle fromWebContents(WebContents webContents) {
+        return (BrowserContextHandle)
+                WolvicBrowserContextJni.get().fromWebContents(webContents);
+    }
+
+    public static BrowserContextHandle fromRenderFrameHost(RenderFrameHost rfh) {
+        return (BrowserContextHandle)
+                WolvicBrowserContextJni.get().fromWebContents(
+                        WebContentsStatics.fromRenderFrameHost(rfh));
+    }
+
+    private WolvicBrowserContext(long nativeWolvicBrowserContext) {
+        mNativeWolvicBrowserContext = nativeWolvicBrowserContext;
+    }
+
+    @CalledByNative
+    private static WolvicBrowserContext create(long nativeWolvicBrowserContext) {
+        return new WolvicBrowserContext(nativeWolvicBrowserContext);
+    }
+
+    @CalledByNative
+    private void onNativeDestroyed() {
+        mNativeWolvicBrowserContext = 0;
+    }
+
+    @Override
+    public long getNativeBrowserContextPointer() {
+        return WolvicBrowserContextJni.get().getBrowserContextPointer(
+                mNativeWolvicBrowserContext);
+    }
+
+    @NativeMethods
+    public interface Natives {
+        Object fromWebContents(WebContents webContents);
+        long getBrowserContextPointer(long nativeWolvicBrowserContext);
+    }
+}

--- a/wolvic/wolvic_browser_context.cc
+++ b/wolvic/wolvic_browser_context.cc
@@ -56,6 +56,7 @@
 #include "wolvic/browser/autocomplete/wolvic_image_decoder.h"
 #include "wolvic/browser/autocomplete/wolvic_password_store_backend.h"
 #include "wolvic/browser/downloads/wolvic_download_manager_delegate.h"
+#include "wolvic/jni_headers/WolvicBrowserContext_jni.h"
 #include "wolvic/wolvic_permission_manager.h"
 
 namespace wolvic {
@@ -66,6 +67,12 @@ WolvicBrowserContext::WolvicBrowserContext(bool off_the_record)
   InitWhileIOAllowed();
   BrowserContextDependencyManager::GetInstance()->CreateBrowserContextServices(
       this);
+
+  JNIEnv* env = base::android::AttachCurrentThread();
+  base::android::ScopedJavaLocalRef<jobject> jobj =
+      Java_WolvicBrowserContext_create(env, reinterpret_cast<intptr_t>(this));
+
+  java_obj_.Reset(env, jobj.obj());
 }
 
 WolvicBrowserContext::~WolvicBrowserContext() {
@@ -81,6 +88,9 @@ WolvicBrowserContext::~WolvicBrowserContext() {
 
   SimpleKeyMap::GetInstance()->Dissociate(this);
   ShutdownStoragePartitions();
+
+  Java_WolvicBrowserContext_onNativeDestroyed(
+      base::android::AttachCurrentThread(), java_obj_);
 }
 
 void WolvicBrowserContext::InitWhileIOAllowed() {
@@ -338,6 +348,29 @@ WolvicSigninClient* WolvicBrowserContext::GetSigninClient() {
   if (!signin_client_)
     CreateSigninClient();
   return signin_client_.get();
+}
+
+base::android::ScopedJavaLocalRef<jobject>
+WolvicBrowserContext::GetJavaObject() {
+  return base::android::ScopedJavaLocalRef<jobject>(java_obj_);
+}
+
+jlong WolvicBrowserContext::GetBrowserContextPointer(JNIEnv* env) {
+  return reinterpret_cast<jlong>(static_cast<content::BrowserContext*>(this));
+}
+
+// static
+base::android::ScopedJavaLocalRef<jobject>
+JNI_WolvicBrowserContext_FromWebContents(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jobject>& jweb_contents) {
+  auto* web_contents = content::WebContents::FromJavaWebContents(jweb_contents);
+  if (!web_contents) {
+    return base::android::ScopedJavaLocalRef<jobject>();
+  }
+
+  return static_cast<WolvicBrowserContext*>(web_contents->GetBrowserContext())
+      ->GetJavaObject();
 }
 
 }  // namespace wolvic

--- a/wolvic/wolvic_browser_context.h
+++ b/wolvic/wolvic_browser_context.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/android/scoped_java_ref.h"
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "components/autofill/core/browser/autocomplete_history_manager.h"
@@ -91,6 +92,9 @@ class WolvicBrowserContext : public content::BrowserContext,
   signin::IdentityManager* GetIdentityManager();
   WolvicSigninClient* GetSigninClient();
 
+  base::android::ScopedJavaLocalRef<jobject> GetJavaObject();
+  jlong GetBrowserContextPointer(JNIEnv* env);
+
  protected:
   std::unique_ptr<content::BackgroundSyncController>
       background_sync_controller_;
@@ -128,6 +132,7 @@ class WolvicBrowserContext : public content::BrowserContext,
   std::unique_ptr<password_manager::FieldInfoManager> field_info_manager_;
   std::unique_ptr<signin::IdentityManager> identity_manager_;
   std::unique_ptr<WolvicSigninClient> signin_client_;
+  base::android::ScopedJavaGlobalRef<jobject> java_obj_;
 };
 
 }  // namespace wolvic


### PR DESCRIPTION
This patch adds WolvicBrowserContext java class that is an wrapper that allows passing WolvicBrowserContext reference around in the Java layer. It has an interface to get BrowserContextHandle interface that provides a pointer to a native BrowserContext, and can be used to by components to take a BrowserContext reference within Java code.