### PR TITLE
Properly set the BrowserContext path and initialize the Sorage

### DIFF
--- a/wolvic/wolvic_browser_context.cc
+++ b/wolvic/wolvic_browser_context.cc
@@ -20,6 +20,7 @@
 #include "components/keyed_service/core/simple_dependency_manager.h"
 #include "components/keyed_service/core/simple_factory_key.h"
 #include "components/keyed_service/core/simple_key_map.h"
+#include "components/leveldb_proto/public/proto_database_provider.h"
 #include "components/network_session_configurator/common/network_switches.h"
 #include "components/origin_trials/browser/leveldb_persistence_provider.h"
 #include "components/origin_trials/browser/origin_trials.h"
@@ -61,10 +62,21 @@
 
 namespace wolvic {
 
-WolvicBrowserContext::WolvicBrowserContext(bool off_the_record)
-    : off_the_record_(off_the_record) {
+WolvicBrowserContext::WolvicBrowserContext(const base::FilePath& path,
+                                           bool off_the_record)
+      : off_the_record_(off_the_record),
+        path_(path) {
   LOG(ERROR) << "WolvicLifecycle WolvicBrowserContext()";
   InitWhileIOAllowed();
+
+  // TODO(jfernandez): I don't know whether we need the ProtoDatabaseProvide instance
+  // at all; we just need to call GetDefaultStoragePartition() once, so that the
+  // StoragePartition instance is created. This is done in //chrome when creatin the
+  // Profile instance.
+  auto proto_db_provider = std::make_unique<leveldb_proto::ProtoDatabaseProvider>(
+      path, /*is_in_memory=*/false);
+  GetDefaultStoragePartition()->SetProtoDatabaseProvider(std::move(proto_db_provider));
+
   BrowserContextDependencyManager::GetInstance()->CreateBrowserContextServices(
       this);
 
@@ -154,13 +166,7 @@ void WolvicBrowserContext::CreateFieldInfoManager() {
 }
 
 base::FilePath WolvicBrowserContext::GetPrefStorePath() {
-  // TODO(zvoit): Assign path based on profile
-  base::FilePath pref_store_path;
-  base::PathService::Get(base::DIR_ANDROID_APP_DATA, &pref_store_path);
-  pref_store_path =
-      pref_store_path.Append(FILE_PATH_LITERAL("Default/Preferences"));
-
-  return pref_store_path;
+  return path_.AppendASCII(FILE_PATH_LITERAL("Preferences"));
 }
 
 void WolvicBrowserContext::CreateUserPrefService() {

--- a/wolvic/wolvic_browser_context.h
+++ b/wolvic/wolvic_browser_context.h
@@ -40,7 +40,7 @@ class WolvicBrowserContext : public content::BrowserContext,
  public:
   // If |delay_services_creation| is true, the owner is responsible for calling
   // CreateBrowserContextServices() for this BrowserContext.
-  WolvicBrowserContext(bool off_the_record);
+  WolvicBrowserContext(const base::FilePath& path, bool off_the_record);
 
   WolvicBrowserContext(const WolvicBrowserContext&) = delete;
   WolvicBrowserContext& operator=(const WolvicBrowserContext&) = delete;

--- a/wolvic/wolvic_main_parts.cc
+++ b/wolvic/wolvic_main_parts.cc
@@ -4,6 +4,8 @@
 
 #include "wolvic/wolvic_main_parts.h"
 
+#include "base/files/file_util.h"
+#include "base/path_service.h"
 #include "content/public/common/result_codes.h"
 #include "content/shell/browser/shell_devtools_manager_delegate.h"
 #include "net/android/network_change_notifier_factory_android.h"
@@ -12,6 +14,20 @@
 #include "wolvic/wolvic_browser_context.h"
 
 namespace wolvic {
+
+// TODO(jfernandez): Should define these constants in a separated file ?
+namespace wolvic {
+  const char kInitialProfile[] = "Default";
+}
+
+namespace {
+
+  static base::FilePath GetInitialProfileDir() {
+  base::FilePath profile_dir;
+  base::PathService::Get(base::DIR_ANDROID_APP_DATA, &profile_dir);
+  return profile_dir.AppendASCII(wolvic::kInitialProfile);
+  }
+}
 
 WolvicMainParts::WolvicMainParts() {}
 
@@ -28,8 +44,8 @@ int WolvicMainParts::PreMainMessageLoopRun() {
   // Required before profile creation).
   PreProfileInit();
 
-  set_browser_context(new WolvicBrowserContext(false));
-  set_off_the_record_browser_context(new WolvicBrowserContext(true));
+  set_browser_context(new WolvicBrowserContext(GetInitialProfileDir(), false));
+  set_off_the_record_browser_context(new WolvicBrowserContext(GetInitialProfileDir(), true));
   content::ShellDevToolsManagerDelegate::StartHttpHandler(
       browser_context_.get());
 


### PR DESCRIPTION
We were relying on the InitWhileIOAllowed to initialize the BrowserContext 'path_' attribute. This change initialize the the path when creating the WolvicBrowserInstance from the WolcMainParts, as chrome does. 

Additionally, in this change we ensure that the StoragePartition is created and initialized. We were relying on the CreatePasswordStore() method, but this is only called the first time Wolvic calls to GetPasswordStore(). 