### PR TITLE
Implement a WebDataService factory

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -83,6 +83,8 @@ shared_library("libcontent_native") {
     "browser/vr/wvr_thread.h",
     "browser/webapps/manifest_builder.cc",
     "browser/webapps/manifest_builder.h",
+    "browser/webdata_services/web_data_service_factory.cc",
+    "browser/webdata_services/web_data_service_factory.h",
     "browser/wolvic_browser_interface_binders.cc",
     "browser/wolvic_browser_interface_binders.h",
     "browser/wolvic_contents.cc",
@@ -112,6 +114,7 @@ shared_library("libcontent_native") {
   deps = [
     ":content_native_lib",
     ":jni_headers",
+    "//components/webdata_services",
     "//components/crash/content/browser",
     "//components/zoom",
     "//device/vr:vr_util",

--- a/wolvic/browser/webdata_services/web_data_service_factory.cc
+++ b/wolvic/browser/webdata_services/web_data_service_factory.cc
@@ -1,0 +1,75 @@
+#include "wolvic/browser/webdata_services/web_data_service_factory.h"
+
+#include "base/files/file_path.h"
+#include "base/functional/bind.h"
+#include "base/no_destructor.h"
+#include "components/webdata_services/web_data_service_wrapper.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+
+// This class is derived from //chrome/webdata_service/WebDataServiceFactory.
+
+namespace wolvic {
+
+namespace {
+
+// Callback to show error dialog on context load error.
+void ContextErrorCallback(WebDataServiceWrapper::ErrorType error_type,
+                          sql::InitStatus status,
+                          const std::string& diagnostics) {
+  // TODO(jfernandez): Implement this error management callback.
+}
+
+std::unique_ptr<KeyedService> BuildWebDataService(
+    content::BrowserContext* context) {
+  const base::FilePath& path = context->GetPath();
+  return std::make_unique<WebDataServiceWrapper>(
+      path, "" /* application locale */ ,
+      content::GetUIThreadTaskRunner({}),
+      base::BindRepeating(&ContextErrorCallback));
+}
+
+} // namespace
+
+WebDataServiceFactory::WebDataServiceFactory() = default;
+
+WebDataServiceFactory::~WebDataServiceFactory() = default;
+
+// static
+WebDataServiceWrapper* WebDataServiceFactory::GetForContext(
+    content::BrowserContext* context,
+    ServiceAccessType access_type) {
+  return GetForBrowserContext(context, access_type);
+}
+
+// static
+WebDataServiceWrapper* WebDataServiceFactory::GetForContextIfExists(
+    content::BrowserContext* context,
+    ServiceAccessType access_type) {
+  return GetForBrowserContextIfExists(context, access_type);
+}
+
+// static
+WebDataServiceFactory* WebDataServiceFactory::GetInstance() {
+  static base::NoDestructor<WebDataServiceFactory> instance;
+  return instance.get();
+}
+
+content::BrowserContext* WebDataServiceFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  // Create a separate instance of the service for the Incognito context.
+  return context;
+}
+
+std::unique_ptr<KeyedService>
+WebDataServiceFactory::BuildServiceInstanceForBrowserContext(
+    content::BrowserContext* context) const {
+  return BuildWebDataService(context);
+}
+
+bool WebDataServiceFactory::ServiceIsNULLWhileTesting() const {
+  return false;
+}
+
+} // wolvic

--- a/wolvic/browser/webdata_services/web_data_service_factory.h
+++ b/wolvic/browser/webdata_services/web_data_service_factory.h
@@ -1,0 +1,50 @@
+#ifndef WOLWIC_BROWSER_WEBDATA_SERVICES_WEB_DATA_SERVICE_FACTORY_H_
+#define WOLWIC_BROWSER_WEBDATA_SERVICES_WEB_DATA_SERVICE_FACTORY_H_
+
+#include "base/memory/ref_counted.h"
+#include "build/build_config.h"
+#include "components/keyed_service/core/service_access_type.h"
+#include "components/webdata_services/web_data_service_wrapper_factory.h"
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}
+
+namespace wolvic {
+
+// Singleton that owns all WebDataServiceWrappers and associates them with
+// Profiles.
+class WebDataServiceFactory
+    : public webdata_services::WebDataServiceWrapperFactory {
+ public:
+  // Returns the WebDataServiceWrapper associated with the |context|.
+  static WebDataServiceWrapper* GetForContext(content::BrowserContext* context,
+                                              ServiceAccessType access_type);
+
+  static WebDataServiceWrapper* GetForContextIfExists(
+      content::BrowserContext* context,
+      ServiceAccessType access_type);
+
+  WebDataServiceFactory(const WebDataServiceFactory&) = delete;
+  WebDataServiceFactory& operator=(const WebDataServiceFactory&) = delete;
+
+  static WebDataServiceFactory* GetInstance();
+
+ private:
+  friend base::NoDestructor<WebDataServiceFactory>;
+
+  WebDataServiceFactory();
+  ~WebDataServiceFactory() override;
+
+  // |BrowserContextKeyedServiceFactory| methods:
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
+      content::BrowserContext* context) const override;
+  bool ServiceIsNULLWhileTesting() const override;
+};
+
+}  // namespace wolvic
+
+#endif  // WOLVIC_BROWSER_WEBDATA_SERVICES_WEB_DATA_SERVICE_FACTORY_H_

--- a/wolvic/wolvic_main_parts.cc
+++ b/wolvic/wolvic_main_parts.cc
@@ -11,6 +11,7 @@
 #include "net/android/network_change_notifier_factory_android.h"
 #include "net/base/network_change_notifier.h"
 #include "wolvic/browser/mojo/wolvic_interface_registrar.h"
+#include "wolvic/browser/webdata_services/web_data_service_factory.h"
 #include "wolvic/wolvic_browser_context.h"
 
 namespace wolvic {
@@ -59,6 +60,7 @@ void WolvicMainParts::PreProfileInit() {
 }
 
 void WolvicMainParts::EnsureBrowserContextKeyedServiceFactoriesBuilt() {
+  WebDataServiceFactory::GetInstance();
 }
 
 void WolvicMainParts::PostMainMessageLoopRun() {


### PR DESCRIPTION
The WebDataServiceWrapper is a KeyedService that owns multiple WebDataServices. One of those is the GetPaymentManifestData which implements the logic to retrieve the WebApp's Manifests, used by the WebPayment APIs when trying to find and launch payment apps.

The WebDataServiceWrapperFactory is an abstract class that needs to be implemented by Wolvic. This change defines a new class WebDataServiceWrapperFactory precisely for that purpose. This provides Wolvic with the specialized KeyedService factory to create instances of the WebDataServices mentioned before.