### PR TITLE
Define a WebContentsFactory class.

### DIFF
--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -66,6 +66,7 @@ shared_library("libcontent_native") {
     "browser/session_settings.h",
     "browser/session_settings_jni.cc",
     "browser/tab_jni.cc",
+    "browser/wolvic_web_contents_factory_jni.cc",
     "browser/vr/moz_external_vr.h",
     "browser/vr/wolvic_xr_integration_client.cc",
     "browser/vr/wolvic_xr_integration_client.h",
@@ -314,6 +315,7 @@ generate_jni("jni_headers") {
     "java/org/chromium/wolvic/WVRSurfaceTexture.java",
     "java/org/chromium/wolvic/WolvicBrowserContext.java",
     "java/org/chromium/wolvic/WolvicWebContentsDelegate.java",
+    "java/org/chromium/wolvic/WolvicWebContentsFactory.java",
     "java/org/chromium/wolvic/mojo/WolvicInterfaceRegistrar.java",
   ]
 }
@@ -337,6 +339,7 @@ android_library("wolvic_java") {
     "java/org/chromium/wolvic/WVRSurfaceTexture.java",
     "java/org/chromium/wolvic/WolvicBrowserContext.java",
     "java/org/chromium/wolvic/WolvicWebContentsDelegate.java",
+    "java/org/chromium/wolvic/WolvicWebContentsFactory.java",
     "java/org/chromium/wolvic/installedapp/WolvicInstalledAppProviderFactory.java",
     "java/org/chromium/wolvic/mojo/WolvicInterfaceRegistrar.java",
   ]
@@ -354,6 +357,8 @@ android_library("wolvic_java") {
     "//mojo/public/java:bindings_java",
     "//services/service_manager/public/java:service_manager_java",
     "//third_party/androidx:androidx_annotation_annotation_java",
+    "//third_party/android_deps:dagger_java",
+    "//third_party/android_deps:javax_inject_javax_inject_java",
     "//third_party/blink/public/mojom:android_mojo_bindings_java",
     "//third_party/jni_zero:jni_zero_java",
     "//ui/android:ui_full_java",

--- a/wolvic/browser/tab_jni.cc
+++ b/wolvic/browser/tab_jni.cc
@@ -36,28 +36,6 @@ void doPageZoom(const JavaParamRef<jobject>& jweb_contents,
 
 }  // namespace
 
-ScopedJavaLocalRef<jobject> JNI_Tab_CreateWebContents(
-    JNIEnv* env,
-    jboolean is_off_the_record) {
-  // TODO(wolvic-chromium#6): Consider handling browser profiles.
-  auto* browser_client = WolvicContentBrowserClient::Get();
-  CHECK(browser_client->browser_context() != nullptr);
-
-  std::unique_ptr<WebContents> web_contents =
-      WebContents::Create(content::WebContents::CreateParams(
-          is_off_the_record ? browser_client->off_the_record_browser_context()
-                            : browser_client->browser_context()));
-
-  auto* web_contents_impl = web_contents.get();
-  auto wolvic_contents =
-      std::make_unique<WolvicContents>(std::move(web_contents));
-  wolvic_contents.release()->Init();
-
-  zoom::ZoomController::CreateForWebContents(web_contents_impl);
-
-  return web_contents_impl->GetJavaWebContents();
-}
-
 void JNI_Tab_AttachWebContents(JNIEnv* env,
                             const JavaParamRef<jobject>& jweb_contents) {
   WebContents* web_contents = WebContents::FromJavaWebContents(jweb_contents);

--- a/wolvic/browser/wolvic_web_contents_factory_jni.cc
+++ b/wolvic/browser/wolvic_web_contents_factory_jni.cc
@@ -1,0 +1,42 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "wolvic/jni_headers/WolvicWebContentsFactory_jni.h"
+
+#include "components/zoom/zoom_controller.h"
+#include "content/public/browser/web_contents.h"
+#include "wolvic/browser/wolvic_contents.h"
+#include "wolvic/browser/wolvic_web_contents_delegate.h"
+#include "wolvic/wolvic_browser_context.h"
+#include "wolvic/wolvic_content_browser_client.h"
+
+using base::android::JavaParamRef;
+using base::android::ScopedJavaLocalRef;
+using content::WebContents;
+
+namespace wolvic {
+
+ScopedJavaLocalRef<jobject> JNI_WolvicWebContentsFactory_CreateWebContents(
+    JNIEnv* env,
+    jboolean is_off_the_record) {
+  // TODO(wolvic-chromium#6): Consider handling browser profiles.
+  auto* browser_client = WolvicContentBrowserClient::Get();
+  CHECK(browser_client->browser_context() != nullptr);
+
+  std::unique_ptr<WebContents> web_contents =
+      WebContents::Create(content::WebContents::CreateParams(
+          is_off_the_record ? browser_client->off_the_record_browser_context()
+                            : browser_client->browser_context()));
+
+  auto* web_contents_impl = web_contents.get();
+  auto wolvic_contents =
+      std::make_unique<WolvicContents>(std::move(web_contents));
+  wolvic_contents.release()->Init();
+
+  zoom::ZoomController::CreateForWebContents(web_contents_impl);
+
+  return web_contents_impl->GetJavaWebContents();
+}
+
+}  // namespace wolvic

--- a/wolvic/java/org/chromium/wolvic/Tab.java
+++ b/wolvic/java/org/chromium/wolvic/Tab.java
@@ -25,6 +25,7 @@ import org.chromium.ui.base.IntentRequestTracker;
 import org.chromium.ui.base.PageTransition;
 import org.chromium.ui.base.ViewAndroidDelegate;
 import org.chromium.wolvic.WolvicWebContentsDelegate;
+import org.chromium.wolvic.WolvicWebContentsFactory;
 
 @JNINamespace("wolvic")
 public class Tab {
@@ -42,10 +43,6 @@ public class Tab {
     private NavigationController mNavigationController;
     private TabCompositorView mCompositorView;
     protected WebContents mWebContents;
-
-    public WebContents createWebContents(boolean is_off_the_record) {
-        return TabJni.get().createWebContents(is_off_the_record);
-    }
 
     private void attachWebContents(WebContents mWebContents) {
         TabJni.get().attachWebContents(mWebContents);
@@ -72,7 +69,7 @@ public class Tab {
             mWebContents = webContents;
             attachWebContents(mWebContents);
         } else {
-            mWebContents = createWebContents(is_off_the_record);
+            mWebContents = WolvicWebContentsFactory.createWebContents(is_off_the_record);
         }
 
         mContentView =
@@ -209,7 +206,6 @@ public class Tab {
 
     @NativeMethods
     public interface Natives {
-        WebContents createWebContents(boolean is_off_the_record);
         void attachWebContents(WebContents webContents);
         void releaseWebContents(WebContents webContents);
         void setWebContentsDelegate(WebContents webContents, WolvicWebContentsDelegate delegate);

--- a/wolvic/java/org/chromium/wolvic/WolvicWebContentsFactory.java
+++ b/wolvic/java/org/chromium/wolvic/WolvicWebContentsFactory.java
@@ -1,0 +1,30 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.wolvic;
+
+import dagger.Reusable;
+
+import org.jni_zero.JNINamespace;
+import org.jni_zero.NativeMethods;
+
+import org.chromium.content_public.browser.WebContents;
+
+import javax.inject.Inject;
+
+@JNINamespace("wolvic")
+@Reusable
+public class WolvicWebContentsFactory {
+    @Inject
+    public WolvicWebContentsFactory() {}
+
+    public static WebContents createWebContents(boolean is_off_the_record) {
+        return WolvicWebContentsFactoryJni.get().createWebContents(is_off_the_record);
+    }
+
+    @NativeMethods
+    public interface Natives {
+        WebContents createWebContents(boolean is_off_the_record);
+    }
+}


### PR DESCRIPTION
The Tab class is implementing the logic to create new WebContent instances.

Moving this logic to an independent Factory class would allow us to reuse it for other services.