### PR TITLE
Set the default user agent to the network context

### DIFF
--- a/wolvic/wolvic_content_browser_client.cc
+++ b/wolvic/wolvic_content_browser_client.cc
@@ -167,6 +167,18 @@ void WolvicContentBrowserClient::ConfigureNetworkContextParams(
   network_context_params->file_paths = network::mojom::NetworkContextFilePaths::New();
   network_context_params->file_paths->http_cache_directory =
       user_data_path.Append(FILE_PATH_LITERAL("Cache"));
+
+  // TODO: Set the desktop user agent by the default, and revisit this to set
+  // the setting value if the payment request solves the UA issue.
+
+  // These values will be used when the network requst has the empty http
+  // header. All network requests created by renderer(web page) already have
+  // the http header, so the value will be used only for the network requests
+  // created by the native code like the payment request.
+  auto* settings = SessionSettings::Get();
+  network_context_params->user_agent =
+      settings->GetDefaultUserAgent(SessionSettings::UserAgentMode::kDesktop);
+  network_context_params->accept_language = "en-us,en";
 }
 
 void WolvicContentBrowserClient::BindMediaServiceReceiver(


### PR DESCRIPTION
This patch sets the desktop user agent by the default to the network context so that we send the network request with the valid user agent in the http header instead of empty string.

Since we have been sending empty UA values ​​so far, sending desktop UA will get a better response from servers. Also, since Meta browser always uses only desktop UA, the impact of this value will be low.

This fixes the payment request issue by empty user agent string when accessing the google pay server. This approach will be simplest and also we are considering other approaches.
- Set the desktop UA to only payment's the network request.
- Override UA before going out the network reqeust on demend.

We will revisit this to set the setting value to the network context's user agent.