### PR TITLE
Support initial extensions in components

### DIFF
--- a/build/config/compontents_extensions_build.gni
+++ b/build/config/compontents_extensions_build.gni
@@ -1,0 +1,5 @@
+declare_args() {
+  enable_extensions_in_components = false
+}
+
+assert(enable_extensions_in_components != (!is_android && !is_ios && !is_castos && !is_fuchsia))

--- a/components/extensions/browser/BUILD.gn
+++ b/components/extensions/browser/BUILD.gn
@@ -1,0 +1,16 @@
+import("//build/config/features.gni")
+import("//build/config/compontents_extensions_build.gni")
+
+assert(enable_extensions_in_components)
+
+static_library("browser") {
+  sources = [
+  ]
+  deps = [
+    "//extensions/browser",
+    "//extensions/common",
+    "//extensions:extensions_resources",
+  ]
+  public_deps = [
+  ]
+}

--- a/components/extensions/browser/DEPS
+++ b/components/extensions/browser/DEPS
@@ -1,0 +1,5 @@
+include_rules = [
+]
+
+specific_include_rules = {
+}

--- a/components/extensions/common/BUILD.gn
+++ b/components/extensions/common/BUILD.gn
@@ -1,0 +1,14 @@
+import("//build/config/features.gni")
+import("//build/config/compontents_extensions_build.gni")
+
+assert(enable_extensions_in_components)
+
+static_library("common") {
+  sources = [
+  ]
+  deps = [
+    "//extensions:extensions_resources",
+  ]
+  public_deps = [
+  ]
+}

--- a/components/extensions/common/DEPS
+++ b/components/extensions/common/DEPS
@@ -1,0 +1,5 @@
+include_rules = [
+]
+
+specific_include_rules = {
+}

--- a/components/extensions/renderer/BUILD.gn
+++ b/components/extensions/renderer/BUILD.gn
@@ -1,0 +1,15 @@
+import("//build/config/features.gni")
+import("//build/config/compontents_extensions_build.gni")
+
+assert(enable_extensions_in_components)
+
+static_library("renderer") {
+  sources = [
+  ]
+  deps = [
+    "//extensions/renderer",
+    "//extensions:extensions_resources",
+  ]
+  public_deps = [
+  ]
+}

--- a/components/extensions/renderer/DEPS
+++ b/components/extensions/renderer/DEPS
@@ -1,0 +1,5 @@
+include_rules = [
+]
+
+specific_include_rules = {
+}

--- a/components/guest_view/browser/BUILD.gn
+++ b/components/guest_view/browser/BUILD.gn
@@ -6,7 +6,11 @@
 # assert to prevent the accidental building of GuestViews on mobile
 # platforms. If you're now using GuestViews on mobile, go ahead and
 # remove this assert.
+import("//build/config/compontents_extensions_build.gni")
+
+if (!enable_extensions_in_components) {
 assert(!is_android)
+}
 
 static_library("browser") {
   output_name = "guest_view_browser"

--- a/components/guest_view/renderer/BUILD.gn
+++ b/components/guest_view/renderer/BUILD.gn
@@ -6,7 +6,11 @@
 # assert to prevent the accidental building of GuestViews on mobile
 # platforms. If you're now using GuestViews on mobile, go ahead and
 # remove this assert.
+import("//build/config/compontents_extensions_build.gni")
+
+if (!enable_extensions_in_components) {
 assert(!is_android && !is_ios)
+}
 
 static_library("renderer") {
   sources = [

--- a/components/keep_alive_registry/BUILD.gn
+++ b/components/keep_alive_registry/BUILD.gn
@@ -1,8 +1,11 @@
 # Copyright 2017 The Chromium Authors
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+import("//build/config/compontents_extensions_build.gni")
 
+if (!enable_extensions_in_components) {
 assert(!is_android)
+}
 
 source_set("keep_alive_registry") {
   sources = [

--- a/extensions/BUILD.gn
+++ b/extensions/BUILD.gn
@@ -2,7 +2,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//testing/test.gni")
 import("//tools/grit/grit_rule.gni")
 import("//tools/grit/repack.gni")
@@ -183,6 +183,12 @@ static_library("test_support") {
     "//third_party/zlib/google:zip",
   ]
 
+  if (enable_extensions_in_components) {
+    deps -= [
+      "//chrome/common:buildflags",
+    ]
+  }
+
   # Generally, //extensions should not depend on //chromeos. However, a number
   # of the APIs and the extensions shell already do. We should try to avoid
   # expanding these dependencies.
@@ -237,6 +243,17 @@ repack("shell_and_test_pak") {
     "//ui/resources",
     "//ui/strings",
   ]
+
+  if (is_android || is_fuchsia || is_ios) {
+    sources -= [
+      "$root_gen_dir/content/browser/devtools/devtools_resources.pak",
+    ]
+
+    deps -= [
+      "//content/browser/devtools:devtools_resources",
+    ]
+  }
+
 }
 
 test("extensions_unittests") {
@@ -272,6 +289,12 @@ test("extensions_unittests") {
     "//ui/gl:test_support",
   ]
 
+  if (enable_extensions_in_components) {
+    deps -= [
+      ":extensions_resources",
+    ]
+  }
+
   data_deps = [
     "//testing/buildbot/filters:extensions_unittests_filters",
     "//third_party/mesa_headers",
@@ -303,6 +326,7 @@ test("extensions_browsertests") {
   data_deps = [ "//third_party/mesa_headers" ]
 }
 
+if (!enable_extensions_in_components) {
 # TODO(rockot) bug 505926: These should be moved to extensions_browsertests but have
 # old dependencies on chrome files. The chrome dependencies should be removed
 # and these moved to the extensions_browsertests target. Currently, we solve
@@ -375,4 +399,5 @@ source_set("chrome_extensions_browsertests_sources") {
   if (is_chromeos_ash) {
     deps += [ "//components/user_manager:test_support" ]
   }
+}
 }

--- a/extensions/browser/BUILD.gn
+++ b/extensions/browser/BUILD.gn
@@ -4,7 +4,7 @@
 
 import("//build/config/chromeos/ui_mode.gni")
 import("//build/config/features.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//pdf/features.gni")
 import("//testing/libfuzzer/fuzzer_test.gni")
 
@@ -69,6 +69,11 @@ source_set("core_keyed_service_factories") {
     "//extensions/browser/updater",
     "//extensions/buildflags",
   ]
+
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
 }
 
 # The set of all sources that are related to the core extensions system.
@@ -655,6 +660,28 @@ source_set("browser_sources") {
     "//url",
   ]
 
+  if (enable_extensions_in_components) {
+    if (is_android) {
+      sources -= [
+        "api/hid/hid_api.cc",
+        "api/hid/hid_api.h",
+        "api/hid/hid_connection_resource.cc",
+        "api/hid/hid_connection_resource.h",
+        "api/hid/hid_device_manager.cc",
+        "api/hid/hid_device_manager.h",
+      ]
+      deps -= [
+        "//components/web_modal",
+        "//services/device/public/cpp/hid",
+      ]
+    }
+
+    deps -= [
+      "//extensions/buildflags",
+    ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
+
   public_deps = [
     "//base",
     "//components/url_matcher",
@@ -1013,6 +1040,11 @@ source_set("unit_tests") {
     "//third_party/leveldatabase",
     "//third_party/zlib/google:zip",
   ]
+
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
 
   if (is_chromeos) {
     deps += [

--- a/extensions/browser/api/BUILD.gn
+++ b/extensions/browser/api/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//extensions/common/api/schema.gni")
 import("//tools/json_schema_compiler/json_schema_api.gni")
 
@@ -100,6 +100,11 @@ source_set("api_keyed_service_factories") {
     "//extensions/browser/api:api_implementations",
     "//extensions/buildflags:buildflags",
   ]
+
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags:buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
 }
 
 # The "glue" layer that adds relevant API registrations to the extensions

--- a/extensions/browser/api/alarms/BUILD.gn
+++ b/extensions/browser/api/alarms/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/app_current_window_internal/BUILD.gn
+++ b/extensions/browser/api/app_current_window_internal/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/app_runtime/BUILD.gn
+++ b/extensions/browser/api/app_runtime/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/app_window/BUILD.gn
+++ b/extensions/browser/api/app_window/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/audio/BUILD.gn
+++ b/extensions/browser/api/audio/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/automation_internal/BUILD.gn
+++ b/extensions/browser/api/automation_internal/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/bluetooth/BUILD.gn
+++ b/extensions/browser/api/bluetooth/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/bluetooth_low_energy/BUILD.gn
+++ b/extensions/browser/api/bluetooth_low_energy/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/bluetooth_socket/BUILD.gn
+++ b/extensions/browser/api/bluetooth_socket/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/cec_private/BUILD.gn
+++ b/extensions/browser/api/cec_private/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/declarative_net_request/BUILD.gn
+++ b/extensions/browser/api/declarative_net_request/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/declarative_net_request/filter_list_converter/BUILD.gn
+++ b/extensions/browser/api/declarative_net_request/filter_list_converter/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions)
 

--- a/extensions/browser/api/device_permissions_prompt.cc
+++ b/extensions/browser/api/device_permissions_prompt.cc
@@ -182,6 +182,7 @@ class UsbDevicePermissionsPrompt : public DevicePermissionsPrompt::Prompt,
       manager_observation_{this};
 };
 
+#if !BUILDFLAG(IS_ANDROID)
 class HidDeviceInfo : public DevicePermissionsPrompt::Prompt::DeviceInfo {
  public:
   explicit HidDeviceInfo(device::mojom::HidDeviceInfoPtr device)
@@ -366,6 +367,7 @@ class HidDevicePermissionsPrompt : public DevicePermissionsPrompt::Prompt,
   DevicePermissionsPrompt::HidDevicesCallback callback_;
   mojo::AssociatedReceiver<device::mojom::HidManagerClient> receiver_{this};
 };
+#endif
 
 }  // namespace
 
@@ -435,6 +437,7 @@ void DevicePermissionsPrompt::AskForUsbDevices(
   ShowDialog();
 }
 
+#if !BUILDFLAG(IS_ANDROID)
 void DevicePermissionsPrompt::AskForHidDevices(
     const Extension* extension,
     content::BrowserContext* context,
@@ -454,6 +457,7 @@ DevicePermissionsPrompt::CreateHidPromptForTest(const Extension* extension,
       extension, nullptr, multiple, std::vector<HidDeviceFilter>(),
       base::DoNothing());
 }
+#endif
 
 // static
 scoped_refptr<DevicePermissionsPrompt::Prompt>
@@ -464,10 +468,12 @@ DevicePermissionsPrompt::CreateUsbPromptForTest(const Extension* extension,
       base::DoNothing());
 }
 
+#if !BUILDFLAG(IS_ANDROID)
 // static
 void DevicePermissionsPrompt::OverrideHidManagerBinderForTesting(
     HidManagerBinder binder) {
   GetHidManagerBinderOverride() = std::move(binder);
 }
+#endif
 
 }  // namespace extensions

--- a/extensions/browser/api/device_permissions_prompt.h
+++ b/extensions/browser/api/device_permissions_prompt.h
@@ -141,7 +141,7 @@ class DevicePermissionsPrompt {
                         bool multiple,
                         std::vector<device::mojom::UsbDeviceFilterPtr> filters,
                         UsbDevicesCallback callback);
-
+#if !BUILDFLAG(IS_ANDROID)
   void AskForHidDevices(const Extension* extension,
                         content::BrowserContext* context,
                         bool multiple,
@@ -151,14 +151,17 @@ class DevicePermissionsPrompt {
   static scoped_refptr<Prompt> CreateHidPromptForTest(
       const Extension* extension,
       bool multiple);
+#endif
   static scoped_refptr<Prompt> CreateUsbPromptForTest(
       const Extension* extension,
       bool multiple);
 
+#if !BUILDFLAG(IS_ANDROID)
   // Allows tests to override how the HidManager interface is bound.
   using HidManagerBinder = base::RepeatingCallback<void(
       mojo::PendingReceiver<device::mojom::HidManager> receiver)>;
   static void OverrideHidManagerBinderForTesting(HidManagerBinder binder);
+#endif
 
  protected:
   virtual void ShowDialog() = 0;

--- a/extensions/browser/api/diagnostics/BUILD.gn
+++ b/extensions/browser/api/diagnostics/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/dns/BUILD.gn
+++ b/extensions/browser/api/dns/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/feedback_private/BUILD.gn
+++ b/extensions/browser/api/feedback_private/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/file_handlers/BUILD.gn
+++ b/extensions/browser/api/file_handlers/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/file_system/BUILD.gn
+++ b/extensions/browser/api/file_system/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/i18n/BUILD.gn
+++ b/extensions/browser/api/i18n/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/idle/BUILD.gn
+++ b/extensions/browser/api/idle/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/lock_screen_data/BUILD.gn
+++ b/extensions/browser/api/lock_screen_data/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/management/BUILD.gn
+++ b/extensions/browser/api/management/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/media_perception_private/BUILD.gn
+++ b/extensions/browser/api/media_perception_private/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/messaging/BUILD.gn
+++ b/extensions/browser/api/messaging/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")
@@ -36,6 +36,11 @@ source_set("messaging") {
     "//extensions/common",
     "//extensions/common/api",
   ]
+
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
 
   public_deps = [ "//extensions/browser:browser_sources" ]
 }

--- a/extensions/browser/api/metrics_private/BUILD.gn
+++ b/extensions/browser/api/metrics_private/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/mime_handler_private/BUILD.gn
+++ b/extensions/browser/api/mime_handler_private/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/networking_private/BUILD.gn
+++ b/extensions/browser/api/networking_private/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/offscreen/BUILD.gn
+++ b/extensions/browser/api/offscreen/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/power/BUILD.gn
+++ b/extensions/browser/api/power/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/printer_provider/BUILD.gn
+++ b/extensions/browser/api/printer_provider/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/runtime/BUILD.gn
+++ b/extensions/browser/api/runtime/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/serial/BUILD.gn
+++ b/extensions/browser/api/serial/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/socket/BUILD.gn
+++ b/extensions/browser/api/socket/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/sockets_tcp/BUILD.gn
+++ b/extensions/browser/api/sockets_tcp/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/sockets_tcp_server/BUILD.gn
+++ b/extensions/browser/api/sockets_tcp_server/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/sockets_udp/BUILD.gn
+++ b/extensions/browser/api/sockets_udp/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/storage/BUILD.gn
+++ b/extensions/browser/api/storage/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/system_cpu/BUILD.gn
+++ b/extensions/browser/api/system_cpu/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/system_info/BUILD.gn
+++ b/extensions/browser/api/system_info/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/system_memory/BUILD.gn
+++ b/extensions/browser/api/system_memory/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/system_network/BUILD.gn
+++ b/extensions/browser/api/system_network/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/system_storage/BUILD.gn
+++ b/extensions/browser/api/system_storage/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/test/BUILD.gn
+++ b/extensions/browser/api/test/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/user_scripts/BUILD.gn
+++ b/extensions/browser/api/user_scripts/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD - style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/virtual_keyboard/BUILD.gn
+++ b/extensions/browser/api/virtual_keyboard/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/virtual_keyboard_private/BUILD.gn
+++ b/extensions/browser/api/virtual_keyboard_private/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/api/webcam_private/BUILD.gn
+++ b/extensions/browser/api/webcam_private/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/chromeos/ui_mode.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/extension_registry.h
+++ b/extensions/browser/extension_registry.h
@@ -19,6 +19,11 @@
 #include "extensions/common/extension_set.h"
 
 #if !BUILDFLAG(ENABLE_EXTENSIONS)
+#undef BUILDFLAG_INTERNAL_ENABLE_EXTENSIONS
+#include "extensions/buildflags/internal/buildflags.h"
+#endif
+
+#if !BUILDFLAG(ENABLE_EXTENSIONS)
 #error "Extensions must be enabled"
 #endif
 

--- a/extensions/browser/extension_system.h
+++ b/extensions/browser/extension_system.h
@@ -18,6 +18,11 @@
 #include "extensions/common/extension_id.h"
 
 #if !BUILDFLAG(ENABLE_EXTENSIONS)
+#undef BUILDFLAG_INTERNAL_ENABLE_EXTENSIONS
+#include "extensions/buildflags/internal/buildflags.h"
+#endif
+
+#if !BUILDFLAG(ENABLE_EXTENSIONS)
 #error "Extensions must be enabled"
 #endif
 

--- a/extensions/browser/extensions_browser_interface_binders.cc
+++ b/extensions/browser/extensions_browser_interface_binders.cc
@@ -11,7 +11,6 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
 #include "extensions/browser/mojo/keep_alive_impl.h"
-#include "extensions/buildflags/buildflags.h"
 #include "extensions/common/extension_api.h"
 #include "extensions/common/mojom/keep_alive.mojom.h"  // nogncheck
 

--- a/extensions/browser/guest_view/web_view/web_ui/BUILD.gn
+++ b/extensions/browser/guest_view/web_view/web_ui/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/guest_view/web_view/web_view_guest.cc
+++ b/extensions/browser/guest_view/web_view/web_view_guest.cc
@@ -172,6 +172,10 @@ static std::string TerminationStatusToString(base::TerminationStatus status) {
     case base::TERMINATION_STATUS_PROCESS_WAS_KILLED_BY_OOM:
       return "oom killed";
 #endif
+#if BUILDFLAG(IS_ANDROID)
+    case base::TERMINATION_STATUS_OOM_PROTECTED:
+      return "oom protected";
+#endif
     case base::TERMINATION_STATUS_OOM:
       return "oom";
     case base::TERMINATION_STATUS_PROCESS_WAS_KILLED:

--- a/extensions/browser/install/BUILD.gn
+++ b/extensions/browser/install/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/kiosk/BUILD.gn
+++ b/extensions/browser/kiosk/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/browser/updater/BUILD.gn
+++ b/extensions/browser/updater/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/buildflags/internal/BUILD.gn
+++ b/extensions/buildflags/internal/BUILD.gn
@@ -1,0 +1,8 @@
+
+import("//build/buildflag_header.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "ENABLE_EXTENSIONS=$enable_extensions" ]
+}

--- a/extensions/buildflags/internal/buildflags.gni
+++ b/extensions/buildflags/internal/buildflags.gni
@@ -1,0 +1,6 @@
+import("//extensions/buildflags/buildflags.gni")
+import("//build/config/compontents_extensions_build.gni")
+
+if (enable_extensions_in_components) {
+  enable_extensions = enable_extensions_in_components
+}

--- a/extensions/common/BUILD.gn
+++ b/extensions/common/BUILD.gn
@@ -5,7 +5,7 @@
 import("//build/config/chromeos/ui_mode.gni")
 import("//build/config/features.gni")
 import("//components/nacl/features.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 import("//testing/libfuzzer/fuzzer_test.gni")
 

--- a/extensions/common/api/BUILD.gn
+++ b/extensions/common/api/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/features.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//extensions/common/api/schema.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 import("//tools/json_schema_compiler/json_features.gni")
@@ -21,6 +21,11 @@ group("api") {
     ":mojom",
     "//extensions/buildflags",
   ]
+
+  if (enable_extensions_in_components) {
+    public_deps -= [ "//extensions/buildflags" ]
+    public_deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
 }
 
 group("extensions_features") {
@@ -48,6 +53,10 @@ generated_json_strings("generated_api_json_strings") {
     "//base",
     "//extensions/buildflags",
   ]
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
   visibility = [ ":api" ]
 }
 
@@ -58,6 +67,10 @@ generated_types("generated_api_types") {
     "//base",
     "//extensions/buildflags",
   ]
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
   visibility = [ ":api" ]
 }
 

--- a/extensions/common/command.cc
+++ b/extensions/common/command.cc
@@ -66,6 +66,9 @@ ui::Accelerator ParseImpl(const std::string& accelerator,
       platform_key != values::kKeybindingPlatformMac &&
       platform_key != values::kKeybindingPlatformChromeOs &&
       platform_key != values::kKeybindingPlatformLinux &&
+#if BUILDFLAG(IS_ANDROID)
+      platform_key != values::kKeybindingPlatformAndroid &&
+#endif
       platform_key != values::kKeybindingPlatformDefault) {
     *error = ErrorUtils::FormatErrorMessageUTF16(
         errors::kInvalidKeyBindingUnknownPlatform, base::NumberToString(index),
@@ -289,6 +292,8 @@ std::string Command::CommandPlatform() {
   // TODO(crbug.com/1312215): Change this once we decide what string should be
   // used for Fuchsia.
   return values::kKeybindingPlatformLinux;
+#elif BUILDFLAG(IS_ANDROID)
+  return values::kKeybindingPlatformAndroid;
 #else
 #error Unsupported platform
 #endif

--- a/extensions/common/extension.h
+++ b/extensions/common/extension.h
@@ -30,6 +30,11 @@
 #include "url/origin.h"
 
 #if !BUILDFLAG(ENABLE_EXTENSIONS)
+#undef BUILDFLAG_INTERNAL_ENABLE_EXTENSIONS
+#include "extensions/buildflags/internal/buildflags.h"
+#endif
+
+#if !BUILDFLAG(ENABLE_EXTENSIONS)
 #error "Extensions must be enabled"
 #endif
 

--- a/extensions/common/manifest_constants.h
+++ b/extensions/common/manifest_constants.h
@@ -191,6 +191,9 @@ inline constexpr char kKeybindingPlatformDefault[] = "default";
 inline constexpr char kKeybindingPlatformLinux[] = "linux";
 inline constexpr char kKeybindingPlatformMac[] = "mac";
 inline constexpr char kKeybindingPlatformWin[] = "windows";
+#if BUILDFLAG(IS_ANDROID)
+inline constexpr char kKeybindingPlatformAndroid[] = "android";
+#endif
 inline constexpr char kKeyAlt[] = "Alt";
 inline constexpr char kKeyComma[] = "Comma";
 inline constexpr char kKeyCommand[] = "Command";

--- a/extensions/components/javascript_dialog_extensions_client/BUILD.gn
+++ b/extensions/components/javascript_dialog_extensions_client/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/components/native_app_window/BUILD.gn
+++ b/extensions/components/native_app_window/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/ui.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/renderer/BUILD.gn
+++ b/extensions/renderer/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/features.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions)
 
@@ -325,6 +325,11 @@ static_library("unit_test_support") {
     "//testing/gtest",
     "//third_party/zlib/google:compression_utils",
   ]
+
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
 }
 
 source_set("unit_tests") {
@@ -404,6 +409,11 @@ source_set("unit_tests") {
     "//third_party/blink/public:blink",
     "//ui/base",
   ]
+
+  if (enable_extensions_in_components) {
+    deps -= [ "//extensions/buildflags" ]
+    deps += [ "//extensions/buildflags/internal:buildflags" ]
+  }
 }
 
 source_set("browser_tests") {

--- a/extensions/shell/BUILD.gn
+++ b/extensions/shell/BUILD.gn
@@ -9,7 +9,7 @@ import("//build/config/ui.gni")
 import("//build/util/lastchange.gni")
 import("//build/util/process_version.gni")
 import("//components/nacl/features.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//testing/test.gni")
 import("//tools/grit/grit_rule.gni")
 import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
@@ -85,6 +85,12 @@ source_set("app_shell_lib") {
 
   if (toolkit_views) {
     deps += [ "//ui/views" ]
+  }
+
+  if (enable_extensions_in_components) {
+    deps -= [
+      "//apps",
+    ]
   }
 
   sources = [
@@ -336,6 +342,12 @@ test("app_shell_unittests") {
     "//ui/gl:test_support",
     "//ui/platform_window",
   ]
+
+  if (enable_extensions_in_components) {
+    deps -= [
+      "//apps",
+    ]
+  }
 
   data_deps = [
     # "//gin", # TODO(dpranke): Either gin or v8 data is needed ...

--- a/extensions/shell/browser/system_logs/BUILD.gn
+++ b/extensions/shell/browser/system_logs/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 
 assert(enable_extensions,
        "Cannot depend on extensions because enable_extensions=false.")

--- a/extensions/shell/common/api/BUILD.gn
+++ b/extensions/shell/common/api/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//tools/json_schema_compiler/json_features.gni")
 
 assert(enable_extensions,

--- a/extensions/strings/BUILD.gn
+++ b/extensions/strings/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/locales.gni")
-import("//extensions/buildflags/buildflags.gni")
+import("//extensions/buildflags/internal/buildflags.gni")
 import("//tools/grit/grit_rule.gni")
 
 assert(enable_extensions)

--- a/wolvic/BUILD.gn
+++ b/wolvic/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/config/android/config.gni")
 import("//build/config/android/rules.gni")
+import("//build/config/compontents_extensions_build.gni")
 import("//device/vr/buildflags/buildflags.gni")
 import("//third_party/jni_zero/jni_zero.gni")
 import("//tools/grit/repack.gni")
@@ -291,6 +292,13 @@ static_library("content_native_lib") {
     "//content/shell/android:content_shell_jni_headers",
     "//ui/android",
   ]
+
+  if (enable_extensions_in_components) {
+    deps += [
+      "//components/extensions/browser",
+      "//components/extensions/common",
+    ]
+  }
 }
 
 generate_build_config_srcjar("build_config_gen") {


### PR DESCRIPTION
This is an initial patch to support Extensions in compontents.
- Add enable_extensions_in_components build flag
- Add //components/extensions initial build
- Enable enable_extensions in //extensions, but not in //chrome
- Disable Hdi device code on Android